### PR TITLE
Disable startup actions

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,3 @@
+{
+	'srcDirectory' : 'src'
+}

--- a/src/PharoLauncher-Core.package/PhLDirectoryBasedImageRepository.class/class/initialize.st
+++ b/src/PharoLauncher-Core.package/PhLDirectoryBasedImageRepository.class/class/initialize.st
@@ -1,4 +1,4 @@
 class initialization
 initialize
-	super initialize.
+
 	PhLStartupManager addToLauncherStartUpList: self

--- a/src/PharoLauncher-Core.package/PhLROCheckStartup.class/class/initialize.st
+++ b/src/PharoLauncher-Core.package/PhLROCheckStartup.class/class/initialize.st
@@ -2,7 +2,7 @@ initialization
 initialize
 	"Must be run before any write acess to the file system.
 	UI should already be usable!"
-	SessionManager default 
+	"SessionManager default 
 		register: (ClassSessionHandler forClassNamed: self name)
 		inCategory: SessionManager default toolsCategory
-		atPriority: 1
+		atPriority: 1"

--- a/src/PharoLauncher-Core.package/PhLSettingBrowser.class/class/initialize.st
+++ b/src/PharoLauncher-Core.package/PhLSettingBrowser.class/class/initialize.st
@@ -1,4 +1,4 @@
 class initialization
 initialize
-	super initialize.
+
 	PhLStartupManager addToLauncherStartUpList: self

--- a/src/PharoLauncher-Core.package/PhLStartupManager.class/class/initialize.st
+++ b/src/PharoLauncher-Core.package/PhLStartupManager.class/class/initialize.st
@@ -1,4 +1,4 @@
 class initialization
 initialize
-	super initialize.
-	SessionManager default registerToolClassNamed: self name
+
+	"SessionManager default registerToolClassNamed: self name"

--- a/src/PharoLauncher-Core.package/monticello.meta/categories.st
+++ b/src/PharoLauncher-Core.package/monticello.meta/categories.st
@@ -1,6 +1,6 @@
 SystemOrganization addCategory: #'PharoLauncher-Core'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Commands'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Model'!
-SystemOrganization addCategory: 'PharoLauncher-Core-Settings'!
-el'!
 SystemOrganization addCategory: #'PharoLauncher-Core-Settings'!
+SystemOrganization addCategory: 'PharoLauncher-Core-Settings'!
+gs'!

--- a/src/PharoLauncher-Core.package/monticello.meta/categories.st
+++ b/src/PharoLauncher-Core.package/monticello.meta/categories.st
@@ -2,3 +2,5 @@ SystemOrganization addCategory: #'PharoLauncher-Core'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Commands'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Model'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Settings'!
+el'!
+SystemOrganization addCategory: #'PharoLauncher-Core-Settings'!


### PR DESCRIPTION
Closes #177: - disable startup actions.- remove several super intialize in class side.Right now, startup actions are very disruptive in development mode: they kill all your windows, create exceptions at startup, try to load settings in a system where settings are non-existent...This PR disables this behavior so we can think about how to solve this properly before re-enabling it.