### PR TITLE
[Issue #226] Improve management of the last modified date

### DIFF
--- a/src/PharoLauncher-Core.package/PhLImage.class/class/settingsOn..st
+++ b/src/PharoLauncher-Core.package/PhLImage.class/class/settingsOn..st
@@ -7,6 +7,4 @@ settingsOn: aBuilder
 		parent: #pharoLauncher;
 		target: self;
 		order: 31;
-		description:
-			'When enabled, Pharo Launcher will start a Shell and launch the image from it. ' , String cr
-				, 'It allows to inherit from the Shell environment variables.' translated
+		description: 'When enabled, Pharo Launcher will start a Shell and launch the image from it. ' , String cr , 'It allows to inherit from the Shell environment variables.'

--- a/src/PharoLauncher-Core.package/PhLImage.class/instance/description.st
+++ b/src/PharoLauncher-Core.package/PhLImage.class/instance/description.st
@@ -1,14 +1,9 @@
 printing
 description
-	| dirName f output |
-	
+	| dirName f |
 	dirName := self file parent fullName.
 	f := (dirName , '/description.txt') asFileReference.
 	
-	output := WriteStream on: String new.
-	
-	output nextPutAll: (f exists
+	^ f exists
 		ifTrue: [ f contents withNoLineLongerThan: 80 ]
-		ifFalse: [ 'There is no description.txt' ]).
-		
-	^output contents
+		ifFalse: [ 'There is no description.txt' ]

--- a/src/PharoLauncher-Core.package/PhLImage.class/instance/summaryInfo.st
+++ b/src/PharoLauncher-Core.package/PhLImage.class/instance/summaryInfo.st
@@ -1,16 +1,12 @@
 printing
 summaryInfo
-	| output |
-	
-	output := WriteStream on: String new.
-	
-	output nextPutAll: 'Last modified: '.
-	self file modificationTime printOn: output.
-	output 
-		cr;
-		nextPutAll: self file parent fullName;
-		cr; cr.
-	
-	output nextPutAll: self description.
-		
-	^output contents
+	^ String
+		streamContents: [ :s | 
+			s nextPutAll: 'Last modified: '.
+			self file modificationTime printOn: s.
+			s
+				cr;
+				nextPutAll: self file parent fullName;
+				cr;
+				cr;
+				nextPutAll: self description ]

--- a/src/PharoLauncher-Core.package/monticello.meta/categories.st
+++ b/src/PharoLauncher-Core.package/monticello.meta/categories.st
@@ -1,6 +1,4 @@
 SystemOrganization addCategory: #'PharoLauncher-Core'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Commands'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Model'!
-SystemOrganization addCategory: #'PharoLauncher-Core-Settings'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Settings'!
-gs'!

--- a/src/PharoLauncher-Core.package/monticello.meta/categories.st
+++ b/src/PharoLauncher-Core.package/monticello.meta/categories.st
@@ -3,3 +3,4 @@ SystemOrganization addCategory: 'PharoLauncher-Core-Commands'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Model'!
 SystemOrganization addCategory: #'PharoLauncher-Core-Settings'!
 SystemOrganization addCategory: 'PharoLauncher-Core-Settings'!
+gs'!

--- a/src/PharoLauncher-Spec.package/Duration.extension/instance/simpleTime.ago..st
+++ b/src/PharoLauncher-Spec.package/Duration.extension/instance/simpleTime.ago..st
@@ -1,0 +1,3 @@
+*PharoLauncher-Spec
+simpleTime: aString ago: aCount
+	^ aCount asFloat floor asString , ' ' , (aString asPluralBasedOn: aCount) , ' ago'

--- a/src/PharoLauncher-Spec.package/Duration.extension/instance/simpleTimeAgo.st
+++ b/src/PharoLauncher-Spec.package/Duration.extension/instance/simpleTimeAgo.st
@@ -1,0 +1,26 @@
+*PharoLauncher-Spec
+simpleTimeAgo
+	"Maybe there is a better way to do that, but for now I'll let it like this."
+	
+	self days > 365
+		ifTrue: [ ^ 'more than a year ago' ].
+	self days > 30
+		ifTrue: [ ^ self simpleTime: 'month' ago: self days / 30 ].
+	self days > 14
+		ifTrue: [ ^ self simpleTime: 'week' ago: self days / 7 ].
+	self days > 7
+		ifTrue: [ ^ 'last week' ].
+	self days > 1
+		ifTrue: [ ^ self simpleTime: 'day' ago: self days ].
+	self days = 1
+		ifTrue: [ ^ 'yesterday' ].
+	self hours > 1
+		ifTrue: [ ^ self simpleTime: 'hour' ago: self hours ].
+	self hours = 1
+		ifTrue: [ ^ 'an hour ago' ].
+	self minutes > 1
+		ifTrue: [ ^ self simpleTime: 'minute' ago: self minutes ].
+	self minutes = 1
+		ifTrue: [ ^ 'a minute ago' ].
+	
+	^ 'just now'

--- a/src/PharoLauncher-Spec.package/Duration.extension/properties.json
+++ b/src/PharoLauncher-Spec.package/Duration.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "Duration"
+}

--- a/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/README.md
+++ b/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/README.md
@@ -1,0 +1,6 @@
+Description
+--------------------
+
+I am an abstract class to manage the display of dates in the Pharo launcher UI. 
+
+My subclasses should each implement a different format strategy.

--- a/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/allStrategies.st
+++ b/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/allStrategies.st
@@ -1,0 +1,3 @@
+accessing
+allStrategies
+	^ self allSubclasses reject: #isAbstract

--- a/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/allStrategiesWithNames.st
+++ b/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/allStrategiesWithNames.st
@@ -1,0 +1,3 @@
+accessing
+allStrategiesWithNames
+	^ self allStrategies collect: [ :each | each label -> each ]

--- a/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/displayStringOf..st
+++ b/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/displayStringOf..st
@@ -1,0 +1,5 @@
+accessing
+displayStringOf: aDateAndTime
+	"Takes as parameter a DateAndTime and return a Text describing this date and time to the user."
+	
+	^ self subclassResponsibility

--- a/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/isAbstract.st
+++ b/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/isAbstract.st
@@ -1,0 +1,3 @@
+testing
+isAbstract
+	^ self = PhLAbstractDateDisplayStrategy

--- a/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/label.st
+++ b/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/class/label.st
@@ -1,0 +1,3 @@
+accessing
+label
+	^ self subclassResponsibility

--- a/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/properties.json
+++ b/src/PharoLauncher-Spec.package/PhLAbstractDateDisplayStrategy.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "CyrilFerlicot 7/20/2018 13:23",
+	"super" : "PhLObject",
+	"category" : "PharoLauncher-Spec",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "PhLAbstractDateDisplayStrategy",
+	"type" : "normal"
+}

--- a/src/PharoLauncher-Spec.package/PhLDateAndTimeDisplayStrategy.class/README.md
+++ b/src/PharoLauncher-Spec.package/PhLDateAndTimeDisplayStrategy.class/README.md
@@ -1,0 +1,8 @@
+Description
+--------------------
+
+Display date with the date and time. 
+
+Example:
+
+2018-07-03 10:37:53

--- a/src/PharoLauncher-Spec.package/PhLDateAndTimeDisplayStrategy.class/class/displayStringOf..st
+++ b/src/PharoLauncher-Spec.package/PhLDateAndTimeDisplayStrategy.class/class/displayStringOf..st
@@ -1,0 +1,8 @@
+accessing
+displayStringOf: aDateAndTime
+	^ (String
+		streamContents: [ :s | 
+			s
+				nextPutAll: aDateAndTime asDate yyyymmdd;
+				space.
+			aDateAndTime asTime print24: true on: s ]) asText

--- a/src/PharoLauncher-Spec.package/PhLDateAndTimeDisplayStrategy.class/class/label.st
+++ b/src/PharoLauncher-Spec.package/PhLDateAndTimeDisplayStrategy.class/class/label.st
@@ -1,0 +1,3 @@
+accessing
+label
+	^ 'Date and time'

--- a/src/PharoLauncher-Spec.package/PhLDateAndTimeDisplayStrategy.class/properties.json
+++ b/src/PharoLauncher-Spec.package/PhLDateAndTimeDisplayStrategy.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "CyrilFerlicot 7/20/2018 13:51",
+	"super" : "PhLAbstractDateDisplayStrategy",
+	"category" : "PharoLauncher-Spec",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "PhLDateAndTimeDisplayStrategy",
+	"type" : "normal"
+}

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/dateDisplayStrategy..st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/dateDisplayStrategy..st
@@ -1,0 +1,3 @@
+accessing
+dateDisplayStrategy: anObject
+	DateDisplayStrategy := anObject

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/dateDisplayStrategy.st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/dateDisplayStrategy.st
@@ -1,0 +1,3 @@
+accessing
+dateDisplayStrategy
+	^ DateDisplayStrategy ifNil: [ DateDisplayStrategy := PhLTimeUntilNowStrategy ]

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/displayColorsForDates..st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/displayColorsForDates..st
@@ -1,0 +1,3 @@
+accessing
+displayColorsForDates: aBoolean
+	DisplayColorsForDates := aBoolean

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/displayColorsForDates.st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/displayColorsForDates.st
@@ -1,0 +1,3 @@
+accessing
+displayColorsForDates
+	^ DisplayColorsForDates ifNil: [ DisplayColorsForDates := true ]

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/settingsOn..st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/class/settingsOn..st
@@ -1,0 +1,19 @@
+settings
+settingsOn: aBuilder
+	<systemsettings>
+	<pharoLauncherSettings>
+	
+	(aBuilder pickOne: #dateDisplayStrategy)
+		label: 'Date format' translated;
+		target: self;
+		parent: ##appearance;
+		order: 32;
+		domainValues: PhLAbstractDateDisplayStrategy allStrategiesWithNames;
+		description: 'Customize the format of the dates in the PharoLauncher UI.'.
+		
+	(aBuilder setting: #displayColorsForDates)
+		label: 'Display dates with colors' translated;
+		parent: #appearance;
+		target: self;
+		order: 34;
+		description: 'When this option is enable it will display the date in colors. The color depend on the senority of the date.'

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/dateDisplayStrategy.st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/dateDisplayStrategy.st
@@ -1,0 +1,3 @@
+accessing
+dateDisplayStrategy
+	^ self class dateDisplayStrategy

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/displayColorsForDate.st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/displayColorsForDate.st
@@ -1,0 +1,3 @@
+accessing
+displayColorsForDate
+	^ self class displayColorsForDates

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/initializeWidgets.st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/initializeWidgets.st
@@ -7,10 +7,7 @@ initializeWidgets
 	(timestampColumn := TreeColumnPresenter new) 
 		headerLabel: 'Last Modified';
 		headerAction: [ self sortContentByDateModfied ];
-		displayBlock: [ :item | 
-			| timestamp |
-			timestamp := item content file modificationTime.
-			timestamp asDate yyyymmdd, ' ', timestamp asTime print24 ];
+		displayBlock: [ :item | self printDateOfLastModificationOf: item ];
 		initialWidth: 250.
 		
 	(archColumn := TreeColumnPresenter new) 

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/printDateOfLastModificationOf..st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/printDateOfLastModificationOf..st
@@ -11,5 +11,5 @@ printDateOfLastModificationOf: anItem
 			delta days < 8
 				ifTrue: [ text makeAllColor: Color green muchDarker ].
 			delta days < 3
-				ifTrue: [ text makeAllColor: Color green ] ].
+				ifTrue: [ text makeAllColor: Color green darker] ].
 	^ text asMorph lock

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/printDateOfLastModificationOf..st
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/instance/printDateOfLastModificationOf..st
@@ -1,0 +1,15 @@
+printing
+printDateOfLastModificationOf: anItem
+	| text date delta |
+	date := anItem content file modificationTime.
+	text := self dateDisplayStrategy displayStringOf: date.
+	self displayColorsForDate
+		ifTrue: [ text makeAllColor: Color darkGray.
+			delta := DateAndTime now - date.
+			delta days < 31
+				ifTrue: [ text makeAllColor: Color orange ].
+			delta days < 8
+				ifTrue: [ text makeAllColor: Color green muchDarker ].
+			delta days < 3
+				ifTrue: [ text makeAllColor: Color green ] ].
+	^ text asMorph lock

--- a/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/properties.json
+++ b/src/PharoLauncher-Spec.package/PhLSearchableTitledTreePresenter.class/properties.json
@@ -4,7 +4,10 @@
 	"category" : "PharoLauncher-Spec",
 	"classinstvars" : [ ],
 	"pools" : [ ],
-	"classvars" : [ ],
+	"classvars" : [
+		"DateDisplayStrategy",
+		"DisplayColorsForDates"
+	],
 	"instvars" : [
 		"filterPattern",
 		"regexMatcher",

--- a/src/PharoLauncher-Spec.package/PhLTimeUntilNowStrategy.class/README.md
+++ b/src/PharoLauncher-Spec.package/PhLTimeUntilNowStrategy.class/README.md
@@ -1,0 +1,10 @@
+Description
+--------------------
+
+Display date by its delta with the current date.
+
+Example:
+
+1 year ago
+2 weeks ago
+3 days ago

--- a/src/PharoLauncher-Spec.package/PhLTimeUntilNowStrategy.class/class/displayStringOf..st
+++ b/src/PharoLauncher-Spec.package/PhLTimeUntilNowStrategy.class/class/displayStringOf..st
@@ -1,0 +1,3 @@
+accessing
+displayStringOf: aDateAndTime
+	^ (DateAndTime now - aDateAndTime) simpleTimeAgo asText

--- a/src/PharoLauncher-Spec.package/PhLTimeUntilNowStrategy.class/class/label.st
+++ b/src/PharoLauncher-Spec.package/PhLTimeUntilNowStrategy.class/class/label.st
@@ -1,0 +1,3 @@
+accessing
+label
+	^ 'Time since now'

--- a/src/PharoLauncher-Spec.package/PhLTimeUntilNowStrategy.class/properties.json
+++ b/src/PharoLauncher-Spec.package/PhLTimeUntilNowStrategy.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "CyrilFerlicot 7/20/2018 13:52",
+	"super" : "PhLAbstractDateDisplayStrategy",
+	"category" : "PharoLauncher-Spec",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "PhLTimeUntilNowStrategy",
+	"type" : "normal"
+}

--- a/src/PharoLauncher-Spec.package/monticello.meta/categories.st
+++ b/src/PharoLauncher-Spec.package/monticello.meta/categories.st
@@ -1,2 +1,3 @@
 SystemOrganization addCategory: #'PharoLauncher-Spec'!
 SystemOrganization addCategory: #'PharoLauncher-Spec-Settings'!
+SystemOrganization addCategory: #'PharoLauncher-Spec-Settings'!

--- a/src/PharoLauncher-Spec.package/monticello.meta/categories.st
+++ b/src/PharoLauncher-Spec.package/monticello.meta/categories.st
@@ -1,3 +1,2 @@
 SystemOrganization addCategory: #'PharoLauncher-Spec'!
 SystemOrganization addCategory: #'PharoLauncher-Spec-Settings'!
-SystemOrganization addCategory: #'PharoLauncher-Spec-Settings'!


### PR DESCRIPTION
This PR add two of Peter's customizations for the launcher.

The first one is to let the user select a display strategy for the "last modified" date and to add the possibility to display it like "3 weeks ago".

The second one is to add a setting to colour the date to know which image was launch recently really easily.
Fixes  https://github.com/pharo-project/pharo-launcher/issues/226