### PR TITLE
backport PharoLauncher-Env-GuillermoPolito.5: Skip reading sources file from HOME in osx

### DIFF
--- a/src/PharoLauncher-Env.package/MacOSPlatform.extension/instance/potentialLocationsOfSourcesFile.st
+++ b/src/PharoLauncher-Env.package/MacOSPlatform.extension/instance/potentialLocationsOfSourcesFile.st
@@ -1,0 +1,10 @@
+*PharoLauncher-Env
+potentialLocationsOfSourcesFile
+	^ {
+		"Take care of .app that have a 'Resources' folder as a sibling of the vm binary"
+		Smalltalk vm fullPath asFileReference parent parent / 'Resources'.
+		Smalltalk vm directory.
+		Smalltalk vm fullPath asFileReference parent.
+		"FileLocator systemApplicationSupport.
+		FileLocator userApplicationSupport."
+	}

--- a/src/PharoLauncher-Env.package/MacOSPlatform.extension/properties.json
+++ b/src/PharoLauncher-Env.package/MacOSPlatform.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "MacOSPlatform"
+}


### PR DESCRIPTION
backport PharoLauncher-Env-GuillermoPolito.5: Skip reading sources file from HOME in osx.
This cannot be read using uFFI at startup because the sources file was not read yet. This means that uFFI will use the decompiled version of the method, and moreover, the AST generated will be cached in the subsequents executions.

This change avoids caching wrong ASTs.