### PR TITLE
A start on the command line interface for Launcher

### DIFF
--- a/src/BaselineOfPharoLauncher/BaselineOfPharoLauncher.class.st
+++ b/src/BaselineOfPharoLauncher/BaselineOfPharoLauncher.class.st
@@ -7,71 +7,68 @@ Class {
 { #category : #baselines }
 BaselineOfPharoLauncher >> baseline: spec [
 	<baseline>
-
-	spec for: #'common' do: [
-		spec 
-			project: 'OSProcess' with: [
-				spec
-					className: #ConfigurationOfOSProcess;
-					versionString: #'stable';
-					loads: #('Core with Output' );
-					repository: 'http://www.squeaksource.com/MetacelloRepository' ];
-			project: 'ProcessWrapper' with: [
-				spec
-					className: #ConfigurationOfProcessWrapper;
-					versionString: #'bleedingEdge';
-					loads: #('Core' );
-					repository: 'http://smalltalkhub.com/mc/hernan/ProcessWrapper/main/' ];
-			baseline: 'PharoWin32' with: [
-				spec
-					repository: 'github://tesonep/pharo-com' ];
-			project: 'Ston' with: [
-				spec
-					className: #ConfigurationOfSton;
-					versionString: #'stable';
-					repository: 'http://ss3.gemstone.com/ss/STON' ];
-			project: 'XMLParser' with: [
-				spec
-					className: #ConfigurationOfXMLParser;
-					versionString: #'stable';
-					loads: #('Core' );
-					repository: 'http://smalltalkhub.com/mc/PharoExtras/XMLParser/main/' ];
-				baseline: #Icetray
-					with: [ spec repository: 'github://guillep/icetray/src' ];
-				package: #FastTableExtentions
-					with: [ spec repository: 'github://sbragagnolo/FastTableExtention/src' ].
+	spec for: #common do: [
+		self externalProjects: spec.
 		spec
-			package: #'ConfigurationOfPharoLauncher'; 
+			package: #ConfigurationOfPharoLauncher;
 			package: #'PharoLauncher-Env';
-			package: #'PharoLauncher-Core' with: [
-				spec requires: #(#'PharoLauncher-Env' #'XMLParser' #'Ston' #'OSProcess' #'ProcessWrapper'). ];
-			package: #'PharoLauncher-Spec' with: [ 
-				spec requires: #(#'PharoLauncher-Core' ). ];
-			package: #'PharoLauncher-IceTray' with: [ spec
-				requires: #(#'PharoLauncher-Core' #Icetray #FastTableExtentions) ];
-			for: #'pharo6.x' do: [
-				spec 
-					package: #'PharoLauncher-Pharo6';
-	            package: #'PharoLauncher-Core' with: [ 
- 	               spec requires: #(#'PharoLauncher-Pharo6') ].
-			];
+			package: #'PharoLauncher-Core' with: [ spec requires: #(#'PharoLauncher-Env' #XMLParser #Ston #OSProcess #ProcessWrapper) ];
+			package: #'PharoLauncher-Spec' with: [ spec requires: #(#'PharoLauncher-Core') ];
+			package: #'PharoLauncher-IceTray' with: [ spec requires: #(#'PharoLauncher-Core' #Icetray #FastTableExtentions) ];
+			package: #'PharoLauncher-Tests-Core' with: [ spec requires: #(#'PharoLauncher-Core') ];
+			package: #'PharoLauncher-Tests-SpecUI' with: [ spec requires: #(#'PharoLauncher-Core' #'PharoLauncher-Spec') ];
+			package: #'PharoLauncher-Tests-Download' with: [ spec requires: #(#'PharoLauncher-Tests-Core') ];
+			package: #'PharoLauncher-Tests-Functional' with: [ spec requires: #(#'PharoLauncher-Core' #'PharoLauncher-Tests-Download') ];
+			package: #'PharoLauncher-CommandLine' with: [ spec requires: #(#'PharoLauncher-Core' Clap) ].
 
-			package: #'PharoLauncher-Tests-Core' with: [
-				spec requires: #(#'PharoLauncher-Core' ). ];
-			package: #'PharoLauncher-Tests-SpecUI' with: [
-				spec requires: #(#'PharoLauncher-Core' #'PharoLauncher-Spec'). ];
-			package: #'PharoLauncher-Tests-Download' with: [
-				spec requires: #(#'PharoLauncher-Tests-Core' ). ];
-			package: #'PharoLauncher-Tests-Functional' with: [
-				spec requires: #(#'PharoLauncher-Core' #'PharoLauncher-Tests-Download'). ].
-		spec 
-			group: 'Default' with: #(#'PharoLauncher-Tests-Core' #'PharoLauncher-Tests-Download' #'PharoLauncher-Core' #'PharoLauncher-Spec' #'PharoLauncher-Tests-SpecUI' #'PharoLauncher-Tests-Functional' #'PharoLauncher-IceTray'). ].
+		spec group: 'Default' with: #(
+			#'PharoLauncher-Core'
+			#'PharoLauncher-Spec'
+			#'PharoLauncher-IceTray'
+			#'PharoLauncher-Tests-Core'
+			#'PharoLauncher-Tests-Download'
+			#'PharoLauncher-Tests-SpecUI'
+			#'PharoLauncher-Tests-Functional'
+		) ].
 
-	spec for: #'pharo6.x' do: [	
+	spec for: #'pharo6.x' do: [
 		self spec70: spec.
 		spec
-			package: #'PharoLauncher-Spec' with: [ 
-				spec requires: #(#'Spec70Compatibility') ] ]
+			package: #'PharoLauncher-Pharo6';
+			package: #'PharoLauncher-Core' with: [ spec requires: #(#'PharoLauncher-Pharo6') ];
+			package: #'PharoLauncher-Spec' with: [ spec requires: #(#Spec70Compatibility) ] ]
+]
+
+{ #category : #baselines }
+BaselineOfPharoLauncher >> externalProjects: spec [
+	spec
+		baseline: 'Clap' with: [ spec repository: 'github://cdlm/clap-st/src'; loads: #(core) ];
+		project: 'Ston'
+			with: [ spec
+				repository: 'http://ss3.gemstone.com/ss/STON';
+				className: #ConfigurationOfSton;
+				versionString: #stable ];
+		project: 'XMLParser'
+			with: [ spec
+				repository: 'http://smalltalkhub.com/mc/PharoExtras/XMLParser/main/';
+				className: #ConfigurationOfXMLParser;
+				versionString: #stable;
+				loads: #('Core') ];
+		project: 'OSProcess'
+			with: [ spec
+				repository: 'http://www.squeaksource.com/MetacelloRepository';
+				className: #ConfigurationOfOSProcess;
+				versionString: #stable;
+				loads: #('Core with Output') ];
+		project: 'ProcessWrapper'
+			with: [ spec
+				repository: 'http://smalltalkhub.com/mc/hernan/ProcessWrapper/main/';
+				className: #ConfigurationOfProcessWrapper;
+				versionString: #bleedingEdge;
+				loads: #('Core') ];
+		baseline: 'PharoWin32' with: [ spec repository: 'github://tesonep/pharo-com' ];
+		baseline: #Icetray with: [ spec repository: 'github://guillep/icetray/src' ];
+		package: #FastTableExtentions with: [ spec repository: 'github://sbragagnolo/FastTableExtention/src' ]
 ]
 
 { #category : #baselines }

--- a/src/PharoLauncher-CommandLine/PhLCommandLine.class.st
+++ b/src/PharoLauncher-CommandLine/PhLCommandLine.class.st
@@ -1,0 +1,145 @@
+Class {
+	#name : #PhLCommandLine,
+	#superclass : #Object,
+	#traits : 'TClapBase',
+	#classTraits : 'TClapBase classTrait',
+	#category : #'PharoLauncher-CommandLine'
+}
+
+{ #category : #'command line' }
+PhLCommandLine class >> buildCommand [
+	^ (ClapCommand withName: 'new')
+		description: 'Create a new image or template';
+		add: ((ClapPositional withName: 'image')
+			description: 'Name of the new image');
+		add: ((ClapPositional withName: 'template')
+			description: 'Name of the template to instanciate');
+		meaning: [ :args |
+			args context stdout << '(TODO: should make a new image)'; lf
+		]
+]
+
+{ #category : #'command line' }
+PhLCommandLine class >> launcher [
+	<commandline>
+	^ (ClapCommand withName: 'launcher')
+			description: 'Manager for Pharo images';
+			add: ClapCommand forHelp;
+			add: self listCommand;
+			add: self runCommand;
+			add: self buildCommand;
+			meaning: [ :args |
+				args context stdout << 'Hello from the Pharo Launcher command-line tool (WIP)'; lf ]
+]
+
+{ #category : #'command line' }
+PhLCommandLine class >> listCommand [
+	^ (ClapCommand withName: 'list')
+		description: 'List known images';
+		add: ClapFlag forHelp;
+		meaning: [ :args |
+			args atName: 'help' ifFound: [ :help | help value; exitSuccess ].
+			args validateAll.
+			
+			(self with: args) executeList ]
+]
+
+{ #category : #'command line' }
+PhLCommandLine class >> runCommand [
+	^ (ClapCommand withName: 'run')
+		description: 'Launch specified image';
+		add: ((ClapPositional withName: 'image')
+			description: 'Name of the image to launch');
+		meaning: [ :args |
+			args atName: 'help' ifFound: [ :help | help value; exitSuccess ].
+			args validateAll.
+			
+			(self with: args) executeRun ]
+]
+
+{ #category : #actions }
+PhLCommandLine >> ambiguousQuery: images [
+	self context stderr in: [ :stderr |
+		stderr << 'Several images matched query:'; lf.
+		self
+			listImages: (self imagesMatching: self imageQuery)
+			on: stderr ].
+
+	self context exitFailure
+]
+
+{ #category : #'command line - entry point' }
+PhLCommandLine >> executeList [
+	self listImages: self images on: self context stdout
+]
+
+{ #category : #'command line - entry point' }
+PhLCommandLine >> executeRun [
+	self
+		imagesMatching: self imageQuery
+		ifExact: [ :img | self launchImage: img ]
+		ifApproximate: [ :imgs |
+			imgs size = 1
+				ifTrue: [ self launchImage: imgs first ]
+				ifFalse: [ self ambiguousQuery: imgs ] ]
+		ifNone: [ self unmatchedQuery ]
+]
+
+{ #category : #accessing }
+PhLCommandLine >> imageQuery [
+	^ (arguments atName: 'image') value
+]
+
+{ #category : #'accessing - launcher' }
+PhLCommandLine >> imageRepo [
+	^ PhLDirectoryBasedImageRepository default
+]
+
+{ #category : #'accessing - launcher' }
+PhLCommandLine >> images [
+	^ self imageRepo images
+]
+
+{ #category : #'accessing - launcher' }
+PhLCommandLine >> imagesMatching: query [
+	| lowercaseQuery |
+	lowercaseQuery := query asLowercase.
+
+	^ self images select:
+		[ :each | each name asLowercase beginsWith: query ]
+]
+
+{ #category : #'accessing - launcher' }
+PhLCommandLine >> imagesMatching: query ifExact: exactBlock ifApproximate: approxBlock ifNone: noneBlock [
+	| lowercaseQuery |
+	lowercaseQuery := query asLowercase.
+
+	^ (self images select: [ :each |
+			each name asLowercase in: [ :name |
+				name = lowercaseQuery ifTrue: [ ^ exactBlock cull: each ].
+				name beginsWith: query ] ])
+		ifEmpty: noneBlock
+		ifNotEmpty: [ :approximateMatches | approxBlock cull: approximateMatches ]
+]
+
+{ #category : #actions }
+PhLCommandLine >> launchImage: anImage [
+	anImage launchWithSettings: false
+]
+
+{ #category : #actions }
+PhLCommandLine >> listImages: images on: aStream [
+	images do: [ :each | aStream << each name; lf ]
+]
+
+{ #category : #actions }
+PhLCommandLine >> unmatchedQuery [
+	self context stderr in: [ :stderr |
+		stderr << 'Could not find image matching query among:'; lf.
+		self
+			listImages: self images
+			on: stderr ].
+	
+	self context exitFailure
+
+]

--- a/src/PharoLauncher-CommandLine/PhLCommandLine.class.st
+++ b/src/PharoLauncher-CommandLine/PhLCommandLine.class.st
@@ -135,7 +135,7 @@ PhLCommandLine >> listImages: images on: aStream [
 { #category : #actions }
 PhLCommandLine >> unmatchedQuery [
 	self context stderr in: [ :stderr |
-		stderr << 'Could not find image matching query among:'; lf.
+		stderr << 'No known image matched query! Available images:'; lf.
 		self
 			listImages: self images
 			on: stderr ].

--- a/src/PharoLauncher-CommandLine/package.st
+++ b/src/PharoLauncher-CommandLine/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'PharoLauncher-CommandLine' }


### PR DESCRIPTION
See #246

I realize the baseline reformatting is a noisy change: I extracted the external projects into a helper method and added the dependencies for Clap.

I can try to split the commits to make the changes more readable if you prefer…