### PR TITLE
Fixes issue #257 (intermittent failure to launch images due to ProcessWrapper causing error 998).

### DIFF
--- a/src/PharoLauncher-Core/PhLProcessWrapper.class.st
+++ b/src/PharoLauncher-Core/PhLProcessWrapper.class.st
@@ -40,18 +40,11 @@ PhLProcessWrapper class >> encode: aCommand [
 PhLProcessWrapper class >> isCommandAvailable: aCommand [
 	| encodedCommand |
 	encodedCommand := self encode: aCommand.
-	
-	Smalltalk os isWindows
-		ifTrue: [ Smalltalk
-				at: #ProcessWrapper
-				ifPresent: [ :processWrapperClass | 
-					^ (processWrapperClass new
-						useStderr;
-						waitForExit;
-						startWithShellCommand: encodedCommand;
-						yourself) stderrStream atEnd ].
-			^ false ].
-	^ (OSProcess waitForCommand: encodedCommand) succeeded
+
+	"This is only used to check for unzip at the moment"
+	^ Smalltalk os isWindows
+		ifTrue: [ ^ false ]
+		ifFalse: [ (OSProcess waitForCommand: encodedCommand) succeeded ]
 ]
 
 { #category : #'execution - public' }
@@ -59,8 +52,8 @@ PhLProcessWrapper class >> waitForCommand: aCommand [
 	| encodedCommand |
 	encodedCommand := self encode: aCommand.
 	^ self new
-		process: ((Smalltalk os isWindows and: [ Smalltalk includesKey: #ProcessWrapper ])
-			ifTrue: [ self waitForWindowsCommand: encodedCommand ]
+		process: (Smalltalk os isWindows
+			ifTrue: [ self windowsCommand: encodedCommand ]
 			ifFalse: [ self waitForLinuxCommand: encodedCommand ]);
 		yourself
 ]
@@ -86,31 +79,13 @@ PhLProcessWrapper class >> waitForLinuxCommand: aCommand [
 ]
 
 { #category : #private }
-PhLProcessWrapper class >> waitForWindowsCommand: commandString [
-	| process success |
-	process := (Smalltalk at: #ProcessWrapper) new.
-	success := process startWithShellCommand: commandString.
-	success ifFalse: [
-		self error: 'command ', commandString ,' failed' ].
-
-	success := process waitForExit.
-	success ifFalse: [
-		self error: 'command ', commandString ,' failed' ].
-	
-	process exitCode = 0 ifFalse: [
-		self error: 'command ', commandString ,' failed' ].
-
-	^ process
+PhLProcessWrapper class >> waitForWindowsCommand: aCommand [ 
+	^ PhLProcess runCommand: aCommand
 ]
 
-{ #category : #private }
+{ #category : #'execution - public' }
 PhLProcessWrapper class >> windowsCommand: aCommand [
-	" Run the command in the background so that the process returns immediately. 
-	It prevents the process to be finalized by ProcessWrapper before the image beiing launched!.
-	More information on START: https://ss64.com/nt/start.html"
-	^ (Smalltalk at: #ProcessWrapper) new
-		startWithShellCommand: 'START /B ', aCommand;
-		yourself
+	^ PhLProcess runAsyncCommand: aCommand
 ]
 
 { #category : #accessing }

--- a/src/PharoLauncher-Core/PhLVirtualMachineManager.class.st
+++ b/src/PharoLauncher-Core/PhLVirtualMachineManager.class.st
@@ -18,7 +18,9 @@ Class {
 
 { #category : #unzipping }
 PhLVirtualMachineManager class >> canUseSytemZip [
-	^ PhLProcessWrapper isCommandAvailable: 'unzip'
+	^ Smalltalk os isWindows
+		ifTrue: [ false ]
+		ifFalse: [ PhLProcessWrapper isCommandAvailable: 'unzip' ]
 ]
 
 { #category : #private }

--- a/src/PharoLauncher-Process/PhLProcess.class.st
+++ b/src/PharoLauncher-Process/PhLProcess.class.st
@@ -63,14 +63,14 @@ PhLProcess class >> memSet: externalStructure value: value [
 PhLProcess class >> runAsyncCommand: command [
 	^ Smalltalk os isWindows
 		ifTrue: [ self createProcess: 'C:\Windows\System32\cmd.exe' command: '/C ', command waits: false]
-		ifFalse: [ self system: command]
+		ifFalse: [ LibC system: command]
 ]
 
 { #category : #'*PharoLauncher-Process' }
 PhLProcess class >> runCommand: command [
 	^ Smalltalk os isWindows
 		ifTrue: [ self createProcess: 'C:\Windows\System32\cmd.exe' command: '/C ', command]
-		ifFalse: [ self system: command]
+		ifFalse: [ LibC system: command]
 ]
 
 { #category : #'*PharoLauncher-Process' }
@@ -91,34 +91,6 @@ PhLProcess >> getLastError [
 { #category : #'*PharoLauncher-Process' }
 PhLProcess >> memSet: ptr value: value size: size [
 	^ self ffiCall: #(ExternalAddress * memset(ExternalAddress * ptr, int value, size_t size))
-]
-
-{ #category : #'as yet unclassified' }
-PhLProcess >> methodsIEdited [
-	"
-	PhLProcessWrapper class >> waitForCommand:
-	PhLProcessWrapper class >> waitForWindowsCommand: 	** deleted (no senders)
-	PhLProcessWrapper class >> windowsCommand: 				** deleted (no senders)
-	PhLProcessWrapper >> command:
-	PhLProcessWrapper class >> isCommandAvailable: 		** commented out (only used to check unzip)
-	PhLVirtualMachineManager class >> canUseSytemZip 		** edited
-	"
-
-	"
-	Removed
-	
-	Smalltalk os isWindows
-		ifTrue: [ Smalltalk
-				at: #ProcessWrapper
-				ifPresent: [ :processWrapperClass | 
-					^ (processWrapperClass new
-						useStderr;
-						waitForExit;
-						startWithShellCommand: encodedCommand;
-						yourself) stderrStream atEnd ].
-			^ false ]."
-
-	
 ]
 
 { #category : #'*PharoLauncher-Process' }

--- a/src/PharoLauncher-Process/PhLProcess.class.st
+++ b/src/PharoLauncher-Process/PhLProcess.class.st
@@ -1,0 +1,132 @@
+Class {
+	#name : #PhLProcess,
+	#superclass : #FFILibrary,
+	#category : #'PharoLauncher-Process'
+}
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> clear: externalStructure [
+	^ self memSet: externalStructure value: 0
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> closeHandle: handle [
+	^ self uniqueInstance closeHandle: handle
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> createProcess: app command: cmd [ 
+	^ self createProcess: app command: cmd waits: true
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> createProcess: app command: cmd waits: waits [
+	| startupInfo processInfo result cmdString kNoWindow |
+	kNoWindow := 16r08000000.
+	cmd ifNotNil: [ cmdString := ExternalAddress fromString: cmd ].
+	startupInfo := PhLStartupInfo externalNew.
+	processInfo := PhLProcessInformation externalNew.
+	result := self uniqueInstance
+		createProcess: app
+		command: (cmdString ifNil: [ ExternalAddress null ])
+		processAttributes: nil
+		threadAttributes: nil
+		inheritHandles: 0
+		creationFlags: kNoWindow
+		environment: nil
+		directory: nil
+		startup: startupInfo getHandle
+		processInformation: processInfo getHandle.
+	result isZero
+		ifTrue: [ ^ result ].
+	waits
+		ifTrue: [ self uniqueInstance waitForSingleObject: processInfo process milliSeconds: 16rffffffff ].
+	self closeHandle: processInfo process.
+	self closeHandle: processInfo thread.
+	processInfo free.
+	startupInfo free.
+	cmdString ifNotNil: [ cmdString free ].
+	^ result
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> getLastError [
+	^ self uniqueInstance getLastError
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> memSet: externalStructure value: value [
+	^ self uniqueInstance memSet: externalStructure getHandle value: value size: externalStructure class structureSize
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> runAsyncCommand: command [
+	^ Smalltalk os isWindows
+		ifTrue: [ self createProcess: 'C:\Windows\System32\cmd.exe' command: '/C ', command waits: false]
+		ifFalse: [ self system: command]
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> runCommand: command [
+	^ Smalltalk os isWindows
+		ifTrue: [ self createProcess: 'C:\Windows\System32\cmd.exe' command: '/C ', command]
+		ifFalse: [ self system: command]
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> closeHandle: handle [
+	^ self ffiCall: #(int CloseHandle(void * handle)) module: #Kernel32
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> createProcess: appName command: command processAttributes: procAttr threadAttributes: threadAttr inheritHandles: inherit creationFlags: flags environment: env directory: dir startup: startup processInformation: processInfo [
+	^ self ffiCall: #(int CreateProcessA (const char * appName, char * command, 0, 0, 0, ulong flags, 0, 0, ExternalAddress * startup, ExternalAddress * processInfo)) module: #Kernel32
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> getLastError [
+	^ self ffiCall: #(uint GetLastError(void)) module: #Kernel32
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> memSet: ptr value: value size: size [
+	^ self ffiCall: #(ExternalAddress * memset(ExternalAddress * ptr, int value, size_t size))
+]
+
+{ #category : #'as yet unclassified' }
+PhLProcess >> methodsIEdited [
+	"
+	PhLProcessWrapper class >> waitForCommand:
+	PhLProcessWrapper class >> waitForWindowsCommand: 	** deleted (no senders)
+	PhLProcessWrapper class >> windowsCommand: 				** deleted (no senders)
+	PhLProcessWrapper >> command:
+	PhLProcessWrapper class >> isCommandAvailable: 		** commented out (only used to check unzip)
+	PhLVirtualMachineManager class >> canUseSytemZip 		** edited
+	"
+
+	"
+	Removed
+	
+	Smalltalk os isWindows
+		ifTrue: [ Smalltalk
+				at: #ProcessWrapper
+				ifPresent: [ :processWrapperClass | 
+					^ (processWrapperClass new
+						useStderr;
+						waitForExit;
+						startWithShellCommand: encodedCommand;
+						yourself) stderrStream atEnd ].
+			^ false ]."
+
+	
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> waitForSingleObject: handle milliSeconds: ms [
+	^ self ffiCall: #( uint WaitForSingleObject (void * handle, uint ms)) module: #Kernel32
+]
+
+{ #category : #'accessing platform' }
+PhLProcess >> win32ModuleName [
+	^ 'msvcrt.dll'
+]

--- a/src/PharoLauncher-Process/PhLProcess.extension.st
+++ b/src/PharoLauncher-Process/PhLProcess.extension.st
@@ -79,14 +79,14 @@ PhLProcess >> memSet: ptr value: value size: size [
 PhLProcess class >> runAsyncCommand: command [
 	^ Smalltalk os isWindows
 		ifTrue: [ self createProcess: 'C:\Windows\System32\cmd.exe' command: '/C ', command waits: false]
-		ifFalse: [ self system: command]
+		ifFalse: [ LibC system: command]
 ]
 
 { #category : #'*PharoLauncher-Process' }
 PhLProcess class >> runCommand: command [
 	^ Smalltalk os isWindows
 		ifTrue: [ self createProcess: 'C:\Windows\System32\cmd.exe' command: '/C ', command]
-		ifFalse: [ self system: command]
+		ifFalse: [ LibC system: command]
 ]
 
 { #category : #'*PharoLauncher-Process' }

--- a/src/PharoLauncher-Process/PhLProcess.extension.st
+++ b/src/PharoLauncher-Process/PhLProcess.extension.st
@@ -1,0 +1,95 @@
+Extension { #name : #PhLProcess }
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> clear: externalStructure [
+	^ self memSet: externalStructure value: 0
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> closeHandle: handle [
+	^ self uniqueInstance closeHandle: handle
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> closeHandle: handle [
+	^ self ffiCall: #(int CloseHandle(void * handle)) module: #Kernel32
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> createProcess: app command: cmd [ 
+	^ self createProcess: app command: cmd waits: true
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> createProcess: appName command: command processAttributes: procAttr threadAttributes: threadAttr inheritHandles: inherit creationFlags: flags environment: env directory: dir startup: startup processInformation: processInfo [
+	^ self ffiCall: #(int CreateProcessA (const char * appName, char * command, 0, 0, 0, ulong flags, 0, 0, ExternalAddress * startup, ExternalAddress * processInfo)) module: #Kernel32
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> createProcess: app command: cmd waits: waits [
+	| startupInfo processInfo result cmdString kNoWindow |
+	kNoWindow := 16r08000000.
+	cmd ifNotNil: [ cmdString := ExternalAddress fromString: cmd ].
+	startupInfo := PhLStartupInfo externalNew.
+	processInfo := PhLProcessInformation externalNew.
+	result := self uniqueInstance
+		createProcess: app
+		command: (cmdString ifNil: [ ExternalAddress null ])
+		processAttributes: nil
+		threadAttributes: nil
+		inheritHandles: 0
+		creationFlags: kNoWindow
+		environment: nil
+		directory: nil
+		startup: startupInfo getHandle
+		processInformation: processInfo getHandle.
+	result isZero
+		ifTrue: [ ^ result ].
+	waits
+		ifTrue: [ self uniqueInstance waitForSingleObject: processInfo process milliSeconds: 16rffffffff ].
+	self closeHandle: processInfo process.
+	self closeHandle: processInfo thread.
+	processInfo free.
+	startupInfo free.
+	cmdString ifNotNil: [ cmdString free ].
+	^ result
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> getLastError [
+	^ self ffiCall: #(uint GetLastError(void)) module: #Kernel32
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> getLastError [
+	^ self uniqueInstance getLastError
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> memSet: externalStructure value: value [
+	^ self uniqueInstance memSet: externalStructure getHandle value: value size: externalStructure class structureSize
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> memSet: ptr value: value size: size [
+	^ self ffiCall: #(ExternalAddress * memset(ExternalAddress * ptr, int value, size_t size))
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> runAsyncCommand: command [
+	^ Smalltalk os isWindows
+		ifTrue: [ self createProcess: 'C:\Windows\System32\cmd.exe' command: '/C ', command waits: false]
+		ifFalse: [ self system: command]
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess class >> runCommand: command [
+	^ Smalltalk os isWindows
+		ifTrue: [ self createProcess: 'C:\Windows\System32\cmd.exe' command: '/C ', command]
+		ifFalse: [ self system: command]
+]
+
+{ #category : #'*PharoLauncher-Process' }
+PhLProcess >> waitForSingleObject: handle milliSeconds: ms [
+	^ self ffiCall: #( uint WaitForSingleObject (void * handle, uint ms)) module: #Kernel32
+]

--- a/src/PharoLauncher-Process/PhLProcessInformation.class.st
+++ b/src/PharoLauncher-Process/PhLProcessInformation.class.st
@@ -1,0 +1,75 @@
+Class {
+	#name : #PhLProcessInformation,
+	#superclass : #FFIExternalStructure,
+	#classVars : [
+		'OFFSET_PROCESS',
+		'OFFSET_PROCESSID',
+		'OFFSET_THREAD',
+		'OFFSET_THREADID'
+	],
+	#category : #'PharoLauncher-Process'
+}
+
+{ #category : #'field definition' }
+PhLProcessInformation class >> fieldsDesc [
+	^ #(
+		void * process;
+		void * thread;
+		uint processId;
+		uint threadId;
+	)
+]
+
+{ #category : #initialization }
+PhLProcessInformation >> initialize [
+	super initialize.
+	PhLProcess clear: self
+]
+
+{ #category : #'accessing structure variables' }
+PhLProcessInformation >> process [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_PROCESS) type: ExternalType void asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+PhLProcessInformation >> process: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_PROCESS put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+PhLProcessInformation >> processId [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_PROCESSID
+]
+
+{ #category : #'accessing structure variables' }
+PhLProcessInformation >> processId: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_PROCESSID put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLProcessInformation >> thread [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_THREAD) type: ExternalType void asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+PhLProcessInformation >> thread: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_THREAD put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+PhLProcessInformation >> threadId [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_THREADID
+]
+
+{ #category : #'accessing structure variables' }
+PhLProcessInformation >> threadId: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_THREADID put: anObject
+]

--- a/src/PharoLauncher-Process/PhLStartupInfo.class.st
+++ b/src/PharoLauncher-Process/PhLStartupInfo.class.st
@@ -1,0 +1,273 @@
+Class {
+	#name : #PhLStartupInfo,
+	#superclass : #FFIExternalStructure,
+	#classVars : [
+		'OFFSET_CB',
+		'OFFSET_DESKTOP',
+		'OFFSET_FILLATTRIBUTE',
+		'OFFSET_FLAGS',
+		'OFFSET_RESERVED',
+		'OFFSET_RESERVED2',
+		'OFFSET_RESERVED3',
+		'OFFSET_SHOWWINDOW',
+		'OFFSET_STDERROR',
+		'OFFSET_STDINPUT',
+		'OFFSET_STDOUTPUT',
+		'OFFSET_TITLE',
+		'OFFSET_X',
+		'OFFSET_XCOUNTCHARS',
+		'OFFSET_XSIZE',
+		'OFFSET_Y',
+		'OFFSET_YCOUNTCHARS',
+		'OFFSET_YSIZE'
+	],
+	#category : #'PharoLauncher-Process'
+}
+
+{ #category : #'field definition' }
+PhLStartupInfo class >> fieldsDesc [
+	"self rebuildFieldAccessors"
+	^ #(
+		uint cb;
+		char * reserved;
+		char * desktop;
+		char * title;
+		uint x;
+		uint y;
+		uint xSize;
+		uint ySize;
+		uint xCountChars;
+		uint yCountChars;
+		uint fillAttribute;
+		uint flags;
+		ushort showWindow;
+		ushort reserved2;
+		char * reserved3;
+		void * stdInput;
+		void * stdOutput;
+		void * stdError;
+	)
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> cb [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_CB
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> cb: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_CB put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> desktop [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_DESKTOP) type: ExternalType char asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> desktop: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_DESKTOP put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> fillAttribute [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_FILLATTRIBUTE
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> fillAttribute: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_FILLATTRIBUTE put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> flags [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_FLAGS
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> flags: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_FLAGS put: anObject
+]
+
+{ #category : #initialization }
+PhLStartupInfo >> initialize [
+	super initialize.
+	PhLProcess clear: self.
+	self cb: self class structureSize
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> reserved [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_RESERVED) type: ExternalType char asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> reserved2 [
+	"This method was automatically generated"
+	^handle unsignedShortAt: OFFSET_RESERVED2
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> reserved2: anObject [
+	"This method was automatically generated"
+	handle unsignedShortAt: OFFSET_RESERVED2 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> reserved3 [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_RESERVED3) type: ExternalType char asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> reserved3: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_RESERVED3 put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> reserved: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_RESERVED put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> showWindow [
+	"This method was automatically generated"
+	^handle unsignedShortAt: OFFSET_SHOWWINDOW
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> showWindow: anObject [
+	"This method was automatically generated"
+	handle unsignedShortAt: OFFSET_SHOWWINDOW put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> stdError [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_STDERROR) type: ExternalType void asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> stdError: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_STDERROR put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> stdInput [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_STDINPUT) type: ExternalType void asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> stdInput: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_STDINPUT put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> stdOutput [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_STDOUTPUT) type: ExternalType void asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> stdOutput: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_STDOUTPUT put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> title [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_TITLE) type: ExternalType char asPointerType
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> title: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_TITLE put: anObject getHandle.
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> x [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_X
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> x: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_X put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> xCountChars [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_XCOUNTCHARS
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> xCountChars: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_XCOUNTCHARS put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> xSize [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_XSIZE
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> xSize: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_XSIZE put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> y [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_Y
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> y: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_Y put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> yCountChars [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_YCOUNTCHARS
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> yCountChars: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_YCOUNTCHARS put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> ySize [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_YSIZE
+]
+
+{ #category : #'accessing structure variables' }
+PhLStartupInfo >> ySize: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_YSIZE put: anObject
+]

--- a/src/PharoLauncher-Process/package.st
+++ b/src/PharoLauncher-Process/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'PharoLauncher-Process' }


### PR DESCRIPTION
Fix to: #257, replacing ProcessWrapper with a more robust wrapper for win32\CreateProcess.Error 998 is a common symptom of uninitialized structs, which I suspect caused the issue with ProcessWrapper. This error stopped immediately after making this fix, and it's been working without any issue for 6 weeks.