### PR TITLE
speedup-image-names-getter

### DIFF
--- a/src/PharoLauncher-Core/PhLDirectoryBasedImageRepository.class.st
+++ b/src/PharoLauncher-Core/PhLDirectoryBasedImageRepository.class.st
@@ -175,30 +175,23 @@ PhLDirectoryBasedImageRepository >> hasImages [
 	^ self images notEmpty
 ]
 
-{ #category : #private }
-PhLDirectoryBasedImageRepository >> imageFromDirectory: aDirectory [
-	"Create an instance of PhLImage representing the Pharo image in aDirectory"
-
-	| imageName imageFiles changeFiles |
-	imageName := aDirectory basename.
-	imageFiles := aDirectory filesMatching: imageName , '.image'.
-	changeFiles := aDirectory filesMatching: imageName , '.changes'.
-	^ (imageFiles size ~= 1 or: [ changeFiles size ~= 1 ])
-		ifTrue: [ nil ]
-		ifFalse: [ PhLImage location: imageFiles first ]
-]
-
 { #category : #accessing }
 PhLDirectoryBasedImageRepository >> imageNames [
-	^ self images collect: #name
+	"For performances reasons we do not use the PhImage objects because we need to parse to much files and this is slow. We just get the list of file names."
+
+	| imageNames |
+	imageNames := OrderedCollection new.
+	self withImagesFilesDo: [ :imageFile | imageNames add: imageFile basename ].
+	^ imageNames
 ]
 
 { #category : #accessing }
 PhLDirectoryBasedImageRepository >> images [
+	"Create an instance of PhLImage representing the Pharo image in all launcher directories"
+
 	| images |
 	images := OrderedCollection new.
-	self baseDirectory directories
-		do: [ :directory | (self imageFromDirectory: directory) ifNotNil: [ :image | images add: image ] ].
+	self withImagesFilesDo: [ :imageFile | images add: (PhLImage location: imageFile) ].
 	^ images
 ]
 
@@ -235,7 +228,7 @@ PhLDirectoryBasedImageRepository >> includesImageNamedCaseInsensitive: anImageNa
 	"Windows OS doesnt care about case for folder names."
 	| lowercaseImageName |
 	lowercaseImageName := anImageName asLowercase.
-	^ self images anySatisfy: [ :image | image name asLowercase = lowercaseImageName ]
+	^ self imageNames anySatisfy: [ :imageName | imageName asLowercase = lowercaseImageName ]
 ]
 
 { #category : #testing }
@@ -325,4 +318,14 @@ PhLDirectoryBasedImageRepository >> roots [
 { #category : #'initialize-release' }
 PhLDirectoryBasedImageRepository >> setBaseDirectory: aLocation [
 	baseDirectory := aLocation
+]
+
+{ #category : #accessing }
+PhLDirectoryBasedImageRepository >> withImagesFilesDo: aBlock [
+	self baseDirectory directories
+		do: [ :aDirectory | 
+			| imageName imageFiles |
+			imageName := aDirectory basename.
+			imageFiles := aDirectory filesMatching: imageName , '.image'.
+			(imageFiles size = 1 and: [ (aDirectory filesMatching: imageName , '.changes') size = 1 ]) ifTrue: [ aBlock value: imageFiles first ] ifFalse: [ nil ] ]
 ]

--- a/src/PharoLauncher-Core/PhLDirectoryBasedImageRepository.class.st
+++ b/src/PharoLauncher-Core/PhLDirectoryBasedImageRepository.class.st
@@ -323,7 +323,6 @@ PhLDirectoryBasedImageRepository >> withImagesFilesCollect: aBlock [
 			imageName := aDirectory basename.
 			imageFiles := aDirectory filesMatching: imageName , '.image'.
 			(imageFiles size = 1 and: [ (aDirectory filesMatching: imageName , '.changes') size = 1 ])
-				ifTrue: [ collection add: (aBlock value: imageFiles first) ]
-				ifFalse: [ nil ].
+				ifTrue: [ collection add: (aBlock value: imageFiles first) ].
 			collection ]
 ]

--- a/src/PharoLauncher-Core/PhLDirectoryBasedImageRepository.class.st
+++ b/src/PharoLauncher-Core/PhLDirectoryBasedImageRepository.class.st
@@ -181,7 +181,7 @@ PhLDirectoryBasedImageRepository >> imageNames [
 
 	| imageNames |
 	imageNames := OrderedCollection new.
-	self withImagesFilesDo: [ :imageFile | imageNames add: imageFile basename ].
+	self withImagesFilesDo: [ :imageFile | imageNames add: imageFile basenameWithoutExtension ].
 	^ imageNames
 ]
 

--- a/src/PharoLauncher-Core/PhLDirectoryBasedImageRepository.class.st
+++ b/src/PharoLauncher-Core/PhLDirectoryBasedImageRepository.class.st
@@ -177,22 +177,14 @@ PhLDirectoryBasedImageRepository >> hasImages [
 
 { #category : #accessing }
 PhLDirectoryBasedImageRepository >> imageNames [
-	"For performances reasons we do not use the PhImage objects because we need to parse to much files and this is slow. We just get the list of file names."
-
-	| imageNames |
-	imageNames := OrderedCollection new.
-	self withImagesFilesDo: [ :imageFile | imageNames add: imageFile basenameWithoutExtension ].
-	^ imageNames
+	^ self withImagesFilesCollect: #basenameWithoutExtension
 ]
 
 { #category : #accessing }
 PhLDirectoryBasedImageRepository >> images [
-	"Create an instance of PhLImage representing the Pharo image in all launcher directories"
+	"Creates instances of PhLImage representing the Pharo images the launcher can manage."
 
-	| images |
-	images := OrderedCollection new.
-	self withImagesFilesDo: [ :imageFile | images add: (PhLImage location: imageFile) ].
-	^ images
+	^ self withImagesFilesCollect: [ :imageFile | PhLImage location: imageFile ]
 ]
 
 { #category : #action }
@@ -321,11 +313,17 @@ PhLDirectoryBasedImageRepository >> setBaseDirectory: aLocation [
 ]
 
 { #category : #accessing }
-PhLDirectoryBasedImageRepository >> withImagesFilesDo: aBlock [
-	self baseDirectory directories
-		do: [ :aDirectory | 
+PhLDirectoryBasedImageRepository >> withImagesFilesCollect: aBlock [
+	"I iterate over all the folders in the launcher image directory. If this directory contains one image and one change file, I execute the block provided by the user and I return the list of results obtained."
+
+	^ self baseDirectory directories
+		inject: OrderedCollection new
+		into: [ :collection :aDirectory | 
 			| imageName imageFiles |
 			imageName := aDirectory basename.
 			imageFiles := aDirectory filesMatching: imageName , '.image'.
-			(imageFiles size = 1 and: [ (aDirectory filesMatching: imageName , '.changes') size = 1 ]) ifTrue: [ aBlock value: imageFiles first ] ifFalse: [ nil ] ]
+			(imageFiles size = 1 and: [ (aDirectory filesMatching: imageName , '.changes') size = 1 ])
+				ifTrue: [ collection add: (aBlock value: imageFiles first) ]
+				ifFalse: [ nil ].
+			collection ]
 ]

--- a/src/PharoLauncher-Tests-Core/PhLDirectoryBasedImageRepositoryTest.class.st
+++ b/src/PharoLauncher-Tests-Core/PhLDirectoryBasedImageRepositoryTest.class.st
@@ -2,23 +2,23 @@
 A PhLDirectoryBasedImageGroupTest is a test class for testing the behavior of PhLDirectoryBasedImageGroup
 "
 Class {
-	#name : #PhLDirectoryBasedImageGroupTest,
+	#name : #PhLDirectoryBasedImageRepositoryTest,
 	#superclass : #ClassTestCase,
-	#category : 'PharoLauncher-Tests-Core'
+	#category : #'PharoLauncher-Tests-Core'
 }
 
 { #category : #coverage }
-PhLDirectoryBasedImageGroupTest >> classToBeTested [
+PhLDirectoryBasedImageRepositoryTest >> classToBeTested [
 	^ PhLDirectoryBasedImageRepository
 ]
 
 { #category : #'instance-creation' }
-PhLDirectoryBasedImageGroupTest >> emptyGroup [
+PhLDirectoryBasedImageRepositoryTest >> emptyGroup [
 	^ self classToBeTested forDirectory: FileSystem memory workingDirectory
 ]
 
 { #category : #'instance-creation' }
-PhLDirectoryBasedImageGroupTest >> newGroupWithAnImage [
+PhLDirectoryBasedImageRepositoryTest >> newGroupWithAnImage [
 	| group baseDirectory |
 	group := self emptyGroup.
 	baseDirectory := group baseDirectory.
@@ -29,7 +29,7 @@ PhLDirectoryBasedImageGroupTest >> newGroupWithAnImage [
 ]
 
 { #category : #'tests-action' }
-PhLDirectoryBasedImageGroupTest >> testCopyImageNamedTo [
+PhLDirectoryBasedImageRepositoryTest >> testCopyImageNamedTo [
 	| group |
 	group := self newGroupWithAnImage.
 	self assert: group imageNames asSet equals: #('test') asSet.
@@ -39,7 +39,7 @@ PhLDirectoryBasedImageGroupTest >> testCopyImageNamedTo [
 ]
 
 { #category : #'tests-action' }
-PhLDirectoryBasedImageGroupTest >> testDeleteImageNamed [
+PhLDirectoryBasedImageRepositoryTest >> testDeleteImageNamed [
 	| group |
 	group := self newGroupWithAnImage.
 	self assert: group imageNames asSet equals: #('test') asSet.
@@ -48,7 +48,7 @@ PhLDirectoryBasedImageGroupTest >> testDeleteImageNamed [
 ]
 
 { #category : #'instance-creation' }
-PhLDirectoryBasedImageGroupTest >> testDirectoryForImageNamed [
+PhLDirectoryBasedImageRepositoryTest >> testDirectoryForImageNamed [
 	| group |
 	group := self emptyGroup.
 	self assert: group images isEmpty.
@@ -56,7 +56,7 @@ PhLDirectoryBasedImageGroupTest >> testDirectoryForImageNamed [
 ]
 
 { #category : #'instance-creation' }
-PhLDirectoryBasedImageGroupTest >> testEmptyByDefault [
+PhLDirectoryBasedImageRepositoryTest >> testEmptyByDefault [
 	| group |
 	group := self emptyGroup.
 	self assert: group images isEmpty.
@@ -64,7 +64,7 @@ PhLDirectoryBasedImageGroupTest >> testEmptyByDefault [
 ]
 
 { #category : #'instance-creation' }
-PhLDirectoryBasedImageGroupTest >> testIgnoreNonConformDirectories [
+PhLDirectoryBasedImageRepositoryTest >> testIgnoreNonConformDirectories [
 	| group baseDirectory |
 	group := self emptyGroup.
 	baseDirectory := group baseDirectory.
@@ -83,14 +83,14 @@ PhLDirectoryBasedImageGroupTest >> testIgnoreNonConformDirectories [
 ]
 
 { #category : #'tests-action' }
-PhLDirectoryBasedImageGroupTest >> testImageNames [
+PhLDirectoryBasedImageRepositoryTest >> testImageNames [
 	| group |
 	group := self newGroupWithAnImage.
 	self assert: group imageNames asSet equals: #('test') asSet.
 ]
 
 { #category : #'tests-action' }
-PhLDirectoryBasedImageGroupTest >> testImages [
+PhLDirectoryBasedImageRepositoryTest >> testImages [
 	| group |
 	group := self newGroupWithAnImage.
 	self assert: group images size equals: 1.
@@ -98,7 +98,7 @@ PhLDirectoryBasedImageGroupTest >> testImages [
 ]
 
 { #category : #'tests-action' }
-PhLDirectoryBasedImageGroupTest >> testMakeUniqueImageName [
+PhLDirectoryBasedImageRepositoryTest >> testMakeUniqueImageName [
 	
 	{ 
 	"	{ basename . 	expectedResult .	{existingNames} } "	
@@ -126,7 +126,7 @@ PhLDirectoryBasedImageGroupTest >> testMakeUniqueImageName [
 ]
 
 { #category : #'tests-action' }
-PhLDirectoryBasedImageGroupTest >> testRenameImageNamedTo [
+PhLDirectoryBasedImageRepositoryTest >> testRenameImageNamedTo [
 	| group |
 	group := self newGroupWithAnImage.
 	self assert: group imageNames asSet equals: #('test') asSet.


### PR DESCRIPTION
Speed up a lot the time to fetch the image names.

On my machine, with multiple images it takes 1.1sec to fetch the image names before. With this PR it goes down to 47ms. 

This participate to reduce the important of #412. 

I still think it is not enough because to add 47ms of overhead each time we type a character is already too much. And I have a SSD and in the future I could get mor images.