### PR TITLE
Speed-up-vm-fetching

### DIFF
--- a/src/PharoLauncher-Core/PhLVirtualMachine.class.st
+++ b/src/PharoLauncher-Core/PhLVirtualMachine.class.st
@@ -110,6 +110,20 @@ PhLVirtualMachine >> downloadUrl [
 		format: { self pharoVersion . self archPath . self manager downloadPathOSTypeSegment . self flavour . self blessing }
 ]
 
+{ #category : #updating }
+PhLVirtualMachine >> ensureExecutionRights [
+	"Unzipping with Pharo does not preserve unix rights and so, the pahro VM executable does not have the execution permission.
+	We have to set it explicitely on Unix and OS X."
+
+	Smalltalk os isWindows ifTrue: [ ^ self ].
+
+	PhLProcessWrapper new
+		shellCommand;
+		addArguments: 'chmod u+x';
+		in: [ :command | self executablesToEnsure do: [ :file | command addArgument: file fullName surroundedByDoubleQuotes ] ];
+		runAndWaitTimeOut: 5 seconds
+]
+
 { #category : #setting }
 PhLVirtualMachine >> executable: aPathOrfileReference [
 	executableRef := aPathOrfileReference asFileReference
@@ -288,7 +302,7 @@ PhLVirtualMachine >> updateFromUrl [
 	self manager class fetch: self downloadUrl to: self vmStore / (self id , '.zip').
 
 	self initializeExecutableRefFrom: self vmStore / self id.
-	self manager ensureExecutionRightsOf: {self}
+	self ensureExecutionRights
 ]
 
 { #category : #accessing }

--- a/src/PharoLauncher-Core/PhLVirtualMachine.class.st
+++ b/src/PharoLauncher-Core/PhLVirtualMachine.class.st
@@ -110,18 +110,6 @@ PhLVirtualMachine >> downloadUrl [
 		format: { self pharoVersion . self archPath . self manager downloadPathOSTypeSegment . self flavour . self blessing }
 ]
 
-{ #category : #ensuring }
-PhLVirtualMachine >> ensureIsExecutable: aPath [
-	"Unzipping with Pharo does not preserve unix rights and so, the pahro VM executable does not have the execution permission.
-	We have to set it explicitely on Unix and OS X."
-	Smalltalk os isWindows 
-		ifFalse: 	[ PhLProcessWrapper new 
-			shellCommand;
-			addArguments: 'chmod u+x';
-			addArgument: aPath surroundedByDoubleQuotes;
-			runAndWaitTimeOut: 5 seconds ]
-]
-
 { #category : #setting }
 PhLVirtualMachine >> executable: aPathOrfileReference [
 	executableRef := aPathOrfileReference asFileReference
@@ -135,6 +123,13 @@ PhLVirtualMachine >> executableFolderPath [
 { #category : #accessing }
 PhLVirtualMachine >> executablePath [
 	^ executableRef fullName
+]
+
+{ #category : #accessing }
+PhLVirtualMachine >> executablesToEnsure [
+	| vmFolder |
+	vmFolder := self vmStore / self id.
+	^ vmFolder exists ifTrue: [ (vmFolder allChildrenMatching: self class executableName) select: #isFile ] ifFalse: [ #() ]
 ]
 
 { #category : #accessing }
@@ -191,17 +186,14 @@ PhLVirtualMachine >> initializeExecutableRefFrom: aFolder [
 	| executables |
 	executables := aFolder allChildrenMatching: self class executableName.
 	Smalltalk os isUnix
-		ifTrue: [ executables select: #isFile thenDo: [ :fileRef | self ensureIsExecutable: fileRef fullName ].
-			"On linux, either the VM exe is at the top level or a bash script at the top level has to be used"
+		ifTrue: [ "On linux, either the VM exe is at the top level or a bash script at the top level has to be used"
 			executableRef := executables
 				detect: [ :fileRef | fileRef parent = aFolder ]
 				ifNone: [ PhLExecutableNotFoundError signalKind: 'executable' inPath: aFolder fullName ].
 			vmBinaryRef := executables
 				detect: [ :fileRef | fileRef binaryReadStreamDo: [ :stream | (stream next: 4) = self class elfMagicNumber ] ]
 				ifNone: [ PhLExecutableNotFoundError signalKind: 'VM binary' inPath: aFolder fullName ] ]
-		ifFalse:
-			[ executableRef := vmBinaryRef := executables detect: #isFile ifNone: [ PhLExecutableNotFoundError signalKind: 'executable' inPath: aFolder fullName ] ].
-	self ensureIsExecutable: executableRef fullName
+		ifFalse: [ executableRef := vmBinaryRef := executables detect: #isFile ifNone: [ PhLExecutableNotFoundError signalKind: 'executable' inPath: aFolder fullName ] ]
 ]
 
 { #category : #initialization }
@@ -292,11 +284,11 @@ PhLVirtualMachine >> showInFolder [
 { #category : #updating }
 PhLVirtualMachine >> updateFromUrl [
 	"fetch a new version of this Virtual Machine if available"
-	self manager class 
-		fetch: self downloadUrl
-		to: self vmStore / (self id , '.zip').
-		
-	executableRef ifNil: [ self initializeExecutableRefFrom: self vmStore / self id ]
+
+	self manager class fetch: self downloadUrl to: self vmStore / (self id , '.zip').
+
+	self initializeExecutableRefFrom: self vmStore / self id.
+	self manager ensureExecutionRightsOf: {self}
 ]
 
 { #category : #accessing }

--- a/src/PharoLauncher-Core/PhLVirtualMachineManager.class.st
+++ b/src/PharoLauncher-Core/PhLVirtualMachineManager.class.st
@@ -294,6 +294,23 @@ PhLVirtualMachineManager >> downloadPathOSTypeSegment [
 
 ]
 
+{ #category : #querying }
+PhLVirtualMachineManager >> ensureExecutionRightsOf: aCollectionOfVms [
+	"Unzipping with Pharo does not preserve unix rights and so, the pahro VM executable does not have the execution permission.
+	We have to set it explicitely on Unix and OS X."
+
+	| executables command |
+	Smalltalk os isWindows ifTrue: [ ^ self ].
+
+	executables := aCollectionOfVms flatCollect: #executablesToEnsure.
+	command := PhLProcessWrapper new
+		shellCommand;
+		addArguments: 'chmod u+x';
+		yourself.
+	executables do: [ :file | command addArgument: file fullName surroundedByDoubleQuotes ].
+	command runAndWaitTimeOut: 5 seconds
+]
+
 { #category : #private }
 PhLVirtualMachineManager >> fetchCompatibleVm [
 	[ self class 
@@ -528,13 +545,12 @@ PhLVirtualMachineManager >> virtualMachine [
 
 { #category : #querying }
 PhLVirtualMachineManager >> virtualMachines [
-	| vmsInVmStore defaultVms |
-	
+	| vmsInVmStore defaultVms allVms |
 	defaultVms := self defaultVirtualMachines.
-	vmsInVmStore := self availableVirtualMachines values
-		reject: [ :vm | defaultVms anySatisfy: [ :diskVM | diskVM id = vm id ] ].
-		
-	^ vmsInVmStore , defaultVms
+	vmsInVmStore := self availableVirtualMachines values reject: [ :vm | defaultVms anySatisfy: [ :diskVM | diskVM id = vm id ] ].
+	allVms := vmsInVmStore , defaultVms.
+	self ensureExecutionRightsOf: allVms.
+	^ allVms
 ]
 
 { #category : #querying }

--- a/src/PharoLauncher-Core/PhLVirtualMachineManager.class.st
+++ b/src/PharoLauncher-Core/PhLVirtualMachineManager.class.st
@@ -294,23 +294,6 @@ PhLVirtualMachineManager >> downloadPathOSTypeSegment [
 
 ]
 
-{ #category : #querying }
-PhLVirtualMachineManager >> ensureExecutionRightsOf: aCollectionOfVms [
-	"Unzipping with Pharo does not preserve unix rights and so, the pahro VM executable does not have the execution permission.
-	We have to set it explicitely on Unix and OS X."
-
-	| executables command |
-	Smalltalk os isWindows ifTrue: [ ^ self ].
-
-	executables := aCollectionOfVms flatCollect: #executablesToEnsure.
-	command := PhLProcessWrapper new
-		shellCommand;
-		addArguments: 'chmod u+x';
-		yourself.
-	executables do: [ :file | command addArgument: file fullName surroundedByDoubleQuotes ].
-	command runAndWaitTimeOut: 5 seconds
-]
-
 { #category : #private }
 PhLVirtualMachineManager >> fetchCompatibleVm [
 	[ self class 
@@ -545,12 +528,10 @@ PhLVirtualMachineManager >> virtualMachine [
 
 { #category : #querying }
 PhLVirtualMachineManager >> virtualMachines [
-	| vmsInVmStore defaultVms allVms |
+	| vmsInVmStore defaultVms |
 	defaultVms := self defaultVirtualMachines.
 	vmsInVmStore := self availableVirtualMachines values reject: [ :vm | defaultVms anySatisfy: [ :diskVM | diskVM id = vm id ] ].
-	allVms := vmsInVmStore , defaultVms.
-	self ensureExecutionRightsOf: allVms.
-	^ allVms
+	^ vmsInVmStore , defaultVms
 ]
 
 { #category : #querying }

--- a/src/PharoLauncher-Spec2/PhLVMPresenter.class.st
+++ b/src/PharoLauncher-Spec2/PhLVMPresenter.class.st
@@ -96,9 +96,8 @@ PhLVMPresenter >> initializePresenters [
 		contextMenuFromCommandsGroup: [ self rootCommandsGroup / 'Context Menu' ];
 		beResizable;
 		beMultipleSelection;
-		yourself.
-	"Run in a separate process to do not block UI. Can take some seconds."
-	[ vmTable items: self datasource virtualMachines ] fork.
+		items: self datasource virtualMachines;
+		yourself
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Speedup vm fetching.

Instead of ensuring the rights of each executables when creating the vms, I now create all the VM then ensure they are executables in one command. 

This also fix a bug. If we updated a VM and already had the executable file in cache, it did not ensured that the new executable was executable.