### PR TITLE
428-Configuration-edition-delete-when-no-argument-is-selected-crash

### DIFF
--- a/src/PharoLauncher-Spec2/PhLLaunchConfigurationPresenter.class.st
+++ b/src/PharoLauncher-Spec2/PhLLaunchConfigurationPresenter.class.st
@@ -118,7 +118,7 @@ PhLLaunchConfigurationPresenter >> configurationName [
 
 { #category : #initialization }
 PhLLaunchConfigurationPresenter >> connectPresenters [
-	configurationTable selectIndex: 1.
+	configurationTable selectIndex: 1
 ]
 
 { #category : #accessing }
@@ -139,8 +139,7 @@ PhLLaunchConfigurationPresenter >> initializePresenters [
 		items: self image launchConfigurations;
 		display: [ :each | each name ];
 		whenSelectionChangedDo: [ :selection | 
-			selectedConfiguration := selection selectedItem
-				ifNil: [ PhLNullLaunchConfiguration new ].
+			selectedConfiguration := selection selectedItem ifNil: [ PhLNullLaunchConfiguration new ].
 			self selectedConfigurationChanged ];
 		yourself.
 	selectedConfigurationNameField := self newTextInput
@@ -149,23 +148,27 @@ PhLLaunchConfigurationPresenter >> initializePresenters [
 	vmList := self newDropList
 		sortingBlock: [ :a :b | a model id > b model id ];
 		display: [ :each | each id ];
-		whenSelectedItemChangedDo:
-			[ :vm | 
-			vm ifNotNil: 
-				[ vm isHeadless
-					ifTrue: [ self addInteractiveImageArgument ] ] ];
+		whenSelectedItemChangedDo: [ :vm | vm ifNotNil: [ vm isHeadless ifTrue: [ self addInteractiveImageArgument ] ] ];
 		yourself.
 	"Run in a separate process to do not block UI. Can take some seconds."
 	[ self initializeVmListContent ] fork.
-	vmArgumentList := (self instantiate: SpEditableListPresenter)
+	(vmArgumentList := self instantiate: SpEditableListPresenter)
 		addItemBlock: [ self application newRequest
 				title: 'New VM argument?';
 				request ];
+		removeItemBlock: [ :item | 
+			item
+				ifNotNil: [ vmArgumentList items remove: item.
+					vmArgumentList refresh ] ];
 		yourself.
-	imageArgumentList := (self instantiate: SpEditableListPresenter)
+	(imageArgumentList := self instantiate: SpEditableListPresenter)
 		addItemBlock: [ self application newRequest
 				title: 'New image argument?';
 				request ];
+		removeItemBlock: [ :item | 
+			item
+				ifNotNil: [ imageArgumentList items remove: item.
+					imageArgumentList refresh ] ];
 		yourself.
 	applyChangesButton := self newButton
 		label: 'Apply';
@@ -223,6 +226,16 @@ PhLLaunchConfigurationPresenter >> saveSelectedConfiguration [
 	self application launchConfigurationEdited: config.
 ]
 
+{ #category : #action }
+PhLLaunchConfigurationPresenter >> selectImageArgumentAt: anIndex [
+	imageArgumentList selectIndex: anIndex
+]
+
+{ #category : #action }
+PhLLaunchConfigurationPresenter >> selectVMArgumentAt: anIndex [
+	vmArgumentList selectIndex: anIndex
+]
+
 { #category : #accessing }
 PhLLaunchConfigurationPresenter >> selectedConfiguration [
 	^ selectedConfiguration
@@ -230,11 +243,12 @@ PhLLaunchConfigurationPresenter >> selectedConfiguration [
 
 { #category : #updating }
 PhLLaunchConfigurationPresenter >> selectedConfigurationChanged [
-
 	selectedConfigurationNameField text: self selectedConfiguration name.
 	self setVmFromConfiguration.
 	vmArgumentList items: self selectedConfiguration vmArguments.
-	imageArgumentList items: self selectedConfiguration imageArguments
+	imageArgumentList items: self selectedConfiguration imageArguments.
+	self selectImageArgumentAt: 1.
+	self selectVMArgumentAt: 1
 ]
 
 { #category : #initialization }

--- a/src/PharoLauncher-Tests-SpecUI/PhLLaunchConfigurationPresenter.extension.st
+++ b/src/PharoLauncher-Tests-SpecUI/PhLLaunchConfigurationPresenter.extension.st
@@ -16,6 +16,16 @@ PhLLaunchConfigurationPresenter >> clickDeleteConfigurationButton [
 ]
 
 { #category : #'*PharoLauncher-Tests-SpecUI' }
+PhLLaunchConfigurationPresenter >> clickDeleteImageArgumentButton [
+	imageArgumentList removeButton click
+]
+
+{ #category : #'*PharoLauncher-Tests-SpecUI' }
+PhLLaunchConfigurationPresenter >> clickDeleteVMArgumentButton [
+	vmArgumentList removeButton click
+]
+
+{ #category : #'*PharoLauncher-Tests-SpecUI' }
 PhLLaunchConfigurationPresenter >> selectConfiguration: aPhLLaunchConfiguration [
 	configurationTable selectItem: aPhLLaunchConfiguration
 ]

--- a/src/PharoLauncher-Tests-SpecUI/PhLLaunchConfigurationPresenterTest.class.st
+++ b/src/PharoLauncher-Tests-SpecUI/PhLLaunchConfigurationPresenterTest.class.st
@@ -173,6 +173,48 @@ PhLLaunchConfigurationPresenterTest >> testImageLaunchConfigurationsUpdatedWhenC
 ]
 
 { #category : #tests }
+PhLLaunchConfigurationPresenterTest >> testRemoveImageArgument [
+	presenter imageArguments add: '--interactive'.
+	self assert: presenter imageArguments size equals: 1.
+
+	presenter selectImageArgumentAt: 1.
+	presenter clickDeleteImageArgumentButton.
+
+	self assertEmpty: presenter imageArguments
+]
+
+{ #category : #tests }
+PhLLaunchConfigurationPresenterTest >> testRemoveImageArgumentWithoutSelectionDoesNotThrowError [
+	presenter imageArguments add: '--interactive'.
+
+	"Unselect"
+	presenter selectImageArgumentAt: 0.
+
+	self shouldnt: [ presenter clickDeleteImageArgumentButton ] raise: NotFound
+]
+
+{ #category : #tests }
+PhLLaunchConfigurationPresenterTest >> testRemoveVMArgument [
+	presenter vmArguments add: '--interactive'.
+	self assert: presenter vmArguments size equals: 1.
+
+	presenter selectVMArgumentAt: 1.
+	presenter clickDeleteVMArgumentButton.
+
+	self assertEmpty: presenter vmArguments
+]
+
+{ #category : #tests }
+PhLLaunchConfigurationPresenterTest >> testRemoveVMArgumentWithoutSelectionDoesNotThrowError [
+	presenter vmArguments add: '--interactive'.
+
+	"Unselect"
+	presenter selectVMArgumentAt: 0.
+
+	self shouldnt: [ presenter clickDeleteVMArgumentButton ] raise: NotFound
+]
+
+{ #category : #tests }
 PhLLaunchConfigurationPresenterTest >> testSelectingAConfigurationAndClosingWindowSelectsItInImagesPresenterToolbar [
 	| config imagesPresenter window |
 	imagesPresenter := PhLTestImagesPresenter new.


### PR DESCRIPTION
Fix deletion of images and vm arguments when none is selected

This also select the first image and vm arguments when we select a configuration.

Fixes #428