### PR TITLE
allow-manual-settings

### DIFF
--- a/src/PharoLauncher-Core/PhLSettingBrowser.class.st
+++ b/src/PharoLauncher-Core/PhLSettingBrowser.class.st
@@ -15,9 +15,12 @@ PhLSettingBrowser class >> initialize [
 
 { #category : #'system startup' }
 PhLSettingBrowser class >> launcherStartUp [
-	PharoLauncherApplication isDeployed
-		ifFalse: [ ^ self ].
-	self preferencesFile ifNotNil: [ self new treeHolder updateSettingNodes ]
+	PharoLauncherApplication isDeployed ifFalse: [ ^ self ].
+
+	self preferencesFile ifNotNil: [ self new treeHolder updateSettingNodes ].
+	
+	"Allow to have manual settings in the preferences foldor of Pharo Launcher."
+	StartupPreferencesLoader default load: (self preferencesFolder filesMatching: '*.st')
 ]
 
 { #category : #'system startup' }


### PR DESCRIPTION
This allows one to write .st files with startup actions to customize the launcher at launch.