### PR TITLE
435-Jenkins-template-can-do-too-many-request

### DIFF
--- a/src/PharoLauncher-Core/PhLJenkins2Entity.class.st
+++ b/src/PharoLauncher-Core/PhLJenkins2Entity.class.st
@@ -6,10 +6,16 @@ Class {
 	#superclass : #PhLAbstractTemplateGroup,
 	#instVars : [
 		'properties',
-		'parent'
+		'parent',
+		'childrenCache'
 	],
 	#category : #'PharoLauncher-Core-Model'
 }
+
+{ #category : #testing }
+PhLJenkins2Entity class >> isAbstract [
+	^ self = PhLJenkins2Entity
+]
 
 { #category : #protected }
 PhLJenkins2Entity class >> jsonFields [
@@ -33,7 +39,15 @@ PhLJenkins2Entity class >> newWithProperties: json [
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
+PhLJenkins2Entity >> children [
+	"Since we need to request the network to get children, it is better to cache them.
+	In the current use of the launcher, the jenkins entities are recreated each time we want to create a new image. Thus, we can cache the children, the probability of the jenkins been updated meanwhile."
+
+	^ childrenCache ifNil: [ childrenCache := super children ]
+]
+
+{ #category : #testing }
 PhLJenkins2Entity >> hasChildren [
 	^ true
 ]


### PR DESCRIPTION
Cache jenkins entities children to speedup the new image UI for jenkins templates.