### PR TITLE
ensure-super-are-called

### DIFF
--- a/src/PharoLauncher-Core/PhLImage.class.st
+++ b/src/PharoLauncher-Core/PhLImage.class.st
@@ -241,8 +241,9 @@ PhLImage >> initializationScript: aFileReference [
 
 { #category : #initialization }
 PhLImage >> initialize [
+	super initialize.
 	launchConfigurations := OrderedCollection new.
-	shouldRunInitializationScript := true.
+	shouldRunInitializationScript := true
 ]
 
 { #category : #testing }

--- a/src/PharoLauncher-Core/PhLProcessWrapper.class.st
+++ b/src/PharoLauncher-Core/PhLProcessWrapper.class.st
@@ -90,10 +90,11 @@ PhLProcessWrapper >> exitCode [
 ]
 
 { #category : #initialization }
-PhLProcessWrapper >> initialize [ 
+PhLProcessWrapper >> initialize [
+	super initialize.
 	arguments := OrderedCollection new.
 	isShellCommand := false.
-	useLoginShell := false.
+	useLoginShell := false
 ]
 
 { #category : #testing }

--- a/src/PharoLauncher-Spec2/PharoLauncherApplication.class.st
+++ b/src/PharoLauncher-Spec2/PharoLauncherApplication.class.st
@@ -225,11 +225,11 @@ PharoLauncherApplication >> imageRepositoryChanged: newImage [
 ]
 
 { #category : #initialization }
-PharoLauncherApplication >> initialize [ 
+PharoLauncherApplication >> initialize [
+	super initialize.
 	openInWorld := false.
-	imageRepository :=  PhLDirectoryBasedImageRepository default.
-	self templatesClearedOnStartup 
-		ifTrue: [ self class resetTemplateRepository ].
+	imageRepository := PhLDirectoryBasedImageRepository default.
+	self templatesClearedOnStartup ifTrue: [ self class resetTemplateRepository ].
 	self resetTemplateRepository
 ]
 

--- a/src/PharoLauncher-Tests-Commands/PhLDeleteImageCommandTest.class.st
+++ b/src/PharoLauncher-Tests-Commands/PhLDeleteImageCommandTest.class.st
@@ -14,8 +14,9 @@ PhLDeleteImageCommandTest >> setUp [
 ]
 
 { #category : #running }
-PhLDeleteImageCommandTest >> tearDown [ 
-	presenter delete
+PhLDeleteImageCommandTest >> tearDown [
+	presenter delete.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Commands/PhLLaunchImageCommandTest.class.st
+++ b/src/PharoLauncher-Tests-Commands/PhLLaunchImageCommandTest.class.st
@@ -18,10 +18,10 @@ PhLLaunchImageCommandTest >> setUp [
 ]
 
 { #category : #running }
-PhLLaunchImageCommandTest >> tearDown [ 
+PhLLaunchImageCommandTest >> tearDown [
 	imageDir ensureDeleteAll.
-	(process isNotNil and: [ process isRunning ])
-		ifTrue: [ process terminate ].
+	(process isNotNil and: [ process isRunning ]) ifTrue: [ process terminate ].
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Commands/PhLLaunchImageFromDiskCommandTest.class.st
+++ b/src/PharoLauncher-Tests-Commands/PhLLaunchImageFromDiskCommandTest.class.st
@@ -21,8 +21,8 @@ PhLLaunchImageFromDiskCommandTest >> setUp [
 PhLLaunchImageFromDiskCommandTest >> tearDown [
 	imageDir ensureDeleteAll.
 	presenter delete.
-	(process isNotNil and: [ process isRunning ])
-		ifTrue: [ process terminate ].
+	(process isNotNil and: [ process isRunning ]) ifTrue: [ process terminate ].
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Core/PhLImageDescriptionUpdaterTest.class.st
+++ b/src/PharoLauncher-Tests-Core/PhLImageDescriptionUpdaterTest.class.st
@@ -15,12 +15,13 @@ Class {
 
 { #category : #running }
 PhLImageDescriptionUpdaterTest >> setUp [
+	super setUp.
 	updater := PhLImageDescriptionUpdaterMock
 		reset;
 		default.
 	rootFs := FileSystem memory root.
 	image := PhLImage location: rootFs / 'one'.
-	image2 := PhLImage location: rootFs / 'two'.
+	image2 := PhLImage location: rootFs / 'two'
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Core/PhLImageTest.class.st
+++ b/src/PharoLauncher-Tests-Core/PhLImageTest.class.st
@@ -11,12 +11,11 @@ Class {
 
 { #category : #running }
 PhLImageTest >> setUp [
+	super setUp.
 	fs := FileSystem memory root.
 	imageFileRef := fs / 'foo.image'.
-	imageFileRef binaryWriteStreamDo: [ :stream | (ZnEndianessReadWriteStream on: stream ) nextLittleEndianNumber: 4 put: 68021 ].
-	image := PhLImage location: imageFileRef.
-	
-
+	imageFileRef binaryWriteStreamDo: [ :stream | (ZnEndianessReadWriteStream on: stream) nextLittleEndianNumber: 4 put: 68021 ].
+	image := PhLImage location: imageFileRef
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Core/PhLTemplateSourcesTest.class.st
+++ b/src/PharoLauncher-Tests-Core/PhLTemplateSourcesTest.class.st
@@ -9,12 +9,14 @@ Class {
 
 { #category : #running }
 PhLTemplateSourcesTest >> setUp [
+	super setUp.
 	sourcesFile := FileSystem memory / 'templates-sources.test'
 ]
 
 { #category : #running }
-PhLTemplateSourcesTest >> tearDown [ 
-	PhLPharoTemplateSources resetSourcesUrl
+PhLTemplateSourcesTest >> tearDown [
+	PhLPharoTemplateSources resetSourcesUrl.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Download/PhLJenkins2EntityTest.class.st
+++ b/src/PharoLauncher-Tests-Download/PhLJenkins2EntityTest.class.st
@@ -57,8 +57,8 @@ PhLJenkins2EntityTest >> setUpResponse: aResponse [
 
 { #category : #running }
 PhLJenkins2EntityTest >> tearDown [
-	super tearDown.
 	PhLDownloadManagerMock remove.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Functional/PhLAbstractTemplateGroupTest.class.st
+++ b/src/PharoLauncher-Tests-Functional/PhLAbstractTemplateGroupTest.class.st
@@ -30,8 +30,8 @@ PhLAbstractTemplateGroupTest >> setUp [
 
 { #category : #running }
 PhLAbstractTemplateGroupTest >> tearDown [
-	super tearDown.
-	PhLDownloadManagerMock remove
+	PhLDownloadManagerMock remove.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Functional/PhLCreateTemplateFromImageTest.class.st
+++ b/src/PharoLauncher-Tests-Functional/PhLCreateTemplateFromImageTest.class.st
@@ -13,8 +13,9 @@ PhLCreateTemplateFromImageTest class >> defaultTimeLimit [
 ]
 
 { #category : #running }
-PhLCreateTemplateFromImageTest >> tearDown [ 
-	template ifNotNil: [ template zipArchive ensureDelete ]
+PhLCreateTemplateFromImageTest >> tearDown [
+	template ifNotNil: [ template zipArchive ensureDelete ].
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Functional/PhLLaunchImageTest.class.st
+++ b/src/PharoLauncher-Tests-Functional/PhLLaunchImageTest.class.st
@@ -37,8 +37,8 @@ PhLLaunchImageTest >> prepare80imageIn: dir [
 { #category : #running }
 PhLLaunchImageTest >> setUp [
 	| uuid |
-	launchInALoginShellBackup := PhLLaunchConfiguration
-		launchInALoginShell.
+	super setUp.
+	launchInALoginShellBackup := PhLLaunchConfiguration launchInALoginShell.
 	PhLLaunchConfiguration launchInALoginShell: false.
 	uuid := UUIDGenerator next asString.
 	imageDir := FileLocator temp / 'Yann-Gaël Bérès' , uuid.
@@ -55,13 +55,15 @@ PhLLaunchImageTest >> setUp [
 ]
 
 { #category : #running }
-PhLLaunchImageTest >> tearDown [ 
+PhLLaunchImageTest >> tearDown [
 	"imageDir ensureDeleteAll "
+
 	PhLLaunchConfiguration launchInALoginShell: launchInALoginShellBackup.
 	tempVmStoreFolder ensureDeleteAll.
-	PhLVirtualMachineManager vmStore: vmStoreBackup.	
+	PhLVirtualMachineManager vmStore: vmStoreBackup.
 	imageDir ensureDeleteAll.
 	resultDir ensureDeleteAll.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-Functional/PhLVirtualMachineManagerFunctionalTest.class.st
+++ b/src/PharoLauncher-Tests-Functional/PhLVirtualMachineManagerFunctionalTest.class.st
@@ -18,15 +18,17 @@ PhLVirtualMachineManagerFunctionalTest >> preSpurHeader [
 
 { #category : #running }
 PhLVirtualMachineManagerFunctionalTest >> setUp [
+	super setUp.
 	vmStoreBackup := PhLVirtualMachineManager vmStore.
-	tempVmStoreFolder := FileLocator temp / self class name, UUIDGenerator next asString.
-	PhLVirtualMachineManager vmStore: tempVmStoreFolder.
+	tempVmStoreFolder := FileLocator temp / self class name , UUIDGenerator next asString.
+	PhLVirtualMachineManager vmStore: tempVmStoreFolder
 ]
 
 { #category : #running }
-PhLVirtualMachineManagerFunctionalTest >> tearDown [ 
+PhLVirtualMachineManagerFunctionalTest >> tearDown [
 	tempVmStoreFolder ensureDeleteAll.
 	PhLVirtualMachineManager vmStore: vmStoreBackup.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-SpecUI/PhLImageCreationPresenterTest.class.st
+++ b/src/PharoLauncher-Tests-SpecUI/PhLImageCreationPresenterTest.class.st
@@ -9,11 +9,12 @@ Class {
 
 { #category : #running }
 PhLImageCreationPresenterTest >> setUp [
-	presenter := PhLImageCreationPresenter newApplication: 
-		(PharoLauncherApplication new
-			scriptsDirectory: FileSystem memory root;
-			yourself).
-
+	super setUp.
+	presenter := PhLImageCreationPresenter
+		newApplication:
+			(PharoLauncherApplication new
+				scriptsDirectory: FileSystem memory root;
+				yourself)
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-SpecUI/PhLImagesPresenterTest.class.st
+++ b/src/PharoLauncher-Tests-SpecUI/PhLImagesPresenterTest.class.st
@@ -8,8 +8,9 @@ Class {
 }
 
 { #category : #running }
-PhLImagesPresenterTest >> tearDown [ 
-	presenter window ifNotNil: #close
+PhLImagesPresenterTest >> tearDown [
+	presenter window ifNotNil: #close.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-SpecUI/PhLLaunchConfigurationPresenterTest.class.st
+++ b/src/PharoLauncher-Tests-SpecUI/PhLLaunchConfigurationPresenterTest.class.st
@@ -16,6 +16,7 @@ PhLLaunchConfigurationPresenterTest >> defaultTimeLimit [
 
 { #category : #running }
 PhLLaunchConfigurationPresenterTest >> setUp [
+	super setUp.
 	image := PhLImage example.
 	image versionFile writeStreamDo: [ :s | s nextPutAll: '80' ].
 	self setUpPresenter
@@ -36,8 +37,9 @@ PhLLaunchConfigurationPresenterTest >> setUpPresenterWithApplication: anSpApplic
 ]
 
 { #category : #running }
-PhLLaunchConfigurationPresenterTest >> tearDown [ 
-	presenter window ifNotNil: #close
+PhLLaunchConfigurationPresenterTest >> tearDown [
+	presenter window ifNotNil: #close.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/PharoLauncher-Tests-SpecUI/PhLScriptPresenterTest.class.st
+++ b/src/PharoLauncher-Tests-SpecUI/PhLScriptPresenterTest.class.st
@@ -11,6 +11,7 @@ Class {
 
 { #category : #running }
 PhLScriptPresenterTest >> setUp [
+	super setUp.
 	scriptFolder := FileSystem memory root.
 	self setUpPresenter
 ]


### PR DESCRIPTION
Ensure some super are called

Usually initialize methods should call super. setUp should start with a super. tearDown should end with a super. 

Some tests are failing on my machine but let's see what Jenkins says.