### PR TITLE
Testing the import of a non-existing image

### DIFF
--- a/src/PharoLauncher-Tests-Commands/PhLImportImageCommandTest.class.st
+++ b/src/PharoLauncher-Tests-Commands/PhLImportImageCommandTest.class.st
@@ -33,3 +33,14 @@ PhLImportImageCommandTest >> testCanImportAnImage [
 		assertCollection: images
 		hasSameElements: #('TestImage' 'foo').
 ]
+
+{ #category : #tests }
+PhLImportImageCommandTest >> testImportNonExistingImage [
+	| command |
+	command := PhLImportImageCommand new.
+	command context: presenter.
+	presenter := presenter
+		requestAnswer: presenter fileSystem / 'tmp' / 'does_not_exists.image'.
+	self should: [ command execute ] raise: FileDoesNotExistException
+
+]


### PR DESCRIPTION
I submit this pull request to suggest a new test method PhLImportImageCommandTest >> #testCanNotImportAnImage.

This method verifies a corner case in which an attempt to import a non-existing file is made. As you can see (line 43) a file which doesn’t exist is imported. And the assertion statement at line 44 verifies that a FileDoesNotExistException is indeed thrown. This is not immediately obvious as the method #PhLDirectoryBasedImageRepository::importImageNamed:andSiblingFilesto: just returns self if the imagefile does not exist.

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.