### PR TITLE
Enh vm image custom hooks

### DIFF
--- a/src/PharoLauncher-Core/Dictionary.extension.st
+++ b/src/PharoLauncher-Core/Dictionary.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #Dictionary }
+
+{ #category : #'*PharoLauncher-Core' }
+Dictionary >> asPhLImage [
+	"old metadata file format"
+
+	^ PhLImage new
+		privOriginTemplate: (self at: #template);
+		yourself
+]

--- a/src/PharoLauncher-Core/Object.extension.st
+++ b/src/PharoLauncher-Core/Object.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Object }
+
+{ #category : #'*PharoLauncher-Core' }
+Object >> asPhLImage [
+	PhLError signal: 'Unrecognized metadata format'
+]

--- a/src/PharoLauncher-Core/PhLImage.class.st
+++ b/src/PharoLauncher-Core/PhLImage.class.st
@@ -33,6 +33,13 @@ Class {
 }
 
 { #category : #accessing }
+PhLImage class >> classForLocation: imageFileReference [
+	^ self allSubclasses
+		detect: [ :cls | cls isClassForLocation: imageFileReference ]
+		ifNone: [ self ]
+]
+
+{ #category : #accessing }
 PhLImage class >> descriptionFileName [
 	^ 'description.txt'
 ]
@@ -60,21 +67,15 @@ PhLImage class >> example32 [
 ]
 
 { #category : #'instance creation' }
-PhLImage class >> imageFromMetadata: imageFileReference [
+PhLImage class >> imageFromMetadata: imageFileReference ifAbsent: aBlock [
 	"Will recreate the image object from its STON serialized version if possible"
 
-	imageFileReference parent / self metadataFileName
-		readStreamDo: [ :stream | 
-			| object |
-			object := (self stonReader on: stream) next.
-			(object isKindOf: PhLImage) ifTrue: [ ^ object ].
-			(object isKindOf: Dictionary)
-				ifTrue: [ "old metadata file format"
-					^ self new
-						privOriginTemplate: (object at: #template);
-						yourself ].
-			PhLError signal: 'Unrecognized metadata format' ]
-		ifAbsent: [ ^ self new ]
+	^ imageFileReference parent / self metadataFileName
+			readStreamDo: [ :stream | 
+				| object |
+				object := (self stonReader on: stream) next.
+				object asPhLImage ]
+			ifAbsent: aBlock
 ]
 
 { #category : #initialization }
@@ -82,9 +83,18 @@ PhLImage class >> initialize [
 	SessionManager default registerUserClassNamed: self name
 ]
 
+{ #category : #testing }
+PhLImage class >> isClassForLocation: imageFileReference [
+		self subclassResponsibility
+]
+
 { #category : #'instance creation' }
 PhLImage class >> location: imageFileReference [
-	^ (self imageFromMetadata: imageFileReference)
+	| instance |
+	instance := self
+		imageFromMetadata: imageFileReference
+		ifAbsent: [ (self classForLocation: imageFileReference) new ].
+	^ instance
 		setLocation: imageFileReference;
 		yourself
 ]
@@ -131,6 +141,11 @@ PhLImage >> architecture [
 	^ architecture ifNil: [ self computeArchitecture. "Always be able to display image architecture" ]
 ]
 
+{ #category : #converting }
+PhLImage >> asPhLImage [
+	^ self
+]
+
 { #category : #testing }
 PhLImage >> canBeLaunched [
 	^ self architecture = '32' 
@@ -165,6 +180,11 @@ PhLImage >> computePharoVersion [
 	self computeArchitecture.
 	self serializeMetadata.
 	^ pharoVersion
+]
+
+{ #category : #accessing }
+PhLImage >> defaultArguments [
+	^ OrderedCollection new
 ]
 
 { #category : #accessing }
@@ -208,10 +228,11 @@ PhLImage >> doNotRunInitializationScript [
 
 { #category : #computing }
 PhLImage >> ensurePharoVersion [
-	(self pharoVersion isNil or: [ self pharoVersion = '' ])
-		ifFalse: [ self vmManager imageVersion: self pharoVersion.
-					^ self pharoVersion ].
-	^ self computePharoVersion.
+	^ (self pharoVersion isNil or: [ self pharoVersion = '' ])
+			ifFalse: [ 
+				self vmManager imageVersion: self pharoVersion.
+				self pharoVersion ]
+			ifTrue: [ self computePharoVersion ]
 	
 ]
 

--- a/src/PharoLauncher-Core/PhLLaunchConfiguration.class.st
+++ b/src/PharoLauncher-Core/PhLLaunchConfiguration.class.st
@@ -125,7 +125,7 @@ PhLLaunchConfiguration >> initializeWithImage: anImage [
 	image := anImage.
 	name := 'new configuration...'.
 	usePharoSettings := true.
-	imageArguments := OrderedCollection new.
+	imageArguments := anImage defaultArguments.
 ]
 
 { #category : #testing }

--- a/src/PharoLauncher-Core/PhLPrivateVirtualMachine.class.st
+++ b/src/PharoLauncher-Core/PhLPrivateVirtualMachine.class.st
@@ -7,8 +7,13 @@ I represent a Pharo virtual machine used to determine an image phar version by r
 Class {
 	#name : #PhLPrivateVirtualMachine,
 	#superclass : #PhLVirtualMachine,
-	#category : 'PharoLauncher-Core-Download'
+	#category : #'PharoLauncher-Core-Download'
 }
+
+{ #category : #testing }
+PhLPrivateVirtualMachine class >> isClassForDirectory: aFileReference private: isPrivateVm [
+	^ isPrivateVm
+]
 
 { #category : #querying }
 PhLPrivateVirtualMachine >> downloadUrl [

--- a/src/PharoLauncher-Core/PhLVirtualMachine.class.st
+++ b/src/PharoLauncher-Core/PhLVirtualMachine.class.st
@@ -30,7 +30,7 @@ PhLVirtualMachine class >> directory: aFileReference [
 { #category : #'instance creation' }
 PhLVirtualMachine class >> directory: aFileReference private: isPrivateVm [
 	| targetClass |
-	targetClass := isPrivateVm ifTrue: [ PhLPrivateVirtualMachine ] ifFalse: [ self ].
+	targetClass := self allSubclasses detect: [ :cls | cls isClassForDirectory: aFileReference private: isPrivateVm ] ifNone: [ self ].
 	^ targetClass new 
 		initializeOn: aFileReference;
 		yourself 
@@ -58,6 +58,11 @@ PhLVirtualMachine class >> id: aString [
 		id: aString;
 		initializeExecutableRef;
 		yourself
+]
+
+{ #category : #testing }
+PhLVirtualMachine class >> isClassForDirectory: aFileReference private: isPrivateVm [
+	self subclassResponsibility
 ]
 
 { #category : #comparing }

--- a/src/PharoLauncher-GToolkit/PLhGtoolkitImage.class.st
+++ b/src/PharoLauncher-GToolkit/PLhGtoolkitImage.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #PLhGtoolkitImage,
+	#superclass : #PhLImage,
+	#category : #'PharoLauncher-GToolkit'
+}
+
+{ #category : #testing }
+PLhGtoolkitImage class >> isClassForLocation: imageFileReference [
+	| versionFile |
+	versionFile := imageFileReference parent / self versionFileName.
+	^ versionFile exists and: [ versionFile contents beginsWith: 'gt-' ]
+]
+
+{ #category : #accessing }
+PLhGtoolkitImage >> defaultArguments [
+	^ super defaultArguments
+		add: '--no-quit';
+		add: '--interactive';
+		yourself
+]

--- a/src/PharoLauncher-GToolkit/PhLGToolkitVirtualMachine.class.st
+++ b/src/PharoLauncher-GToolkit/PhLGToolkitVirtualMachine.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #PhLGToolkitVirtualMachine,
+	#superclass : #PhLVirtualMachine,
+	#category : #'PharoLauncher-GToolkit'
+}
+
+{ #category : #querying }
+PhLGToolkitVirtualMachine class >> executableName [
+	^ 'GlamorousToolkit'
+]
+
+{ #category : #testing }
+PhLGToolkitVirtualMachine class >> isClassForDirectory: aFileReference private: isPrivateVm [
+	^ aFileReference basename beginsWith: 'gt-'
+]

--- a/src/PharoLauncher-GToolkit/package.st
+++ b/src/PharoLauncher-GToolkit/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'PharoLauncher-GToolkit' }

--- a/src/PharoLauncher-Tests-Functional/PhLOsXMojaveTestImage.class.st
+++ b/src/PharoLauncher-Tests-Functional/PhLOsXMojaveTestImage.class.st
@@ -8,6 +8,11 @@ Class {
 	#category : #'PharoLauncher-Tests-Functional'
 }
 
+{ #category : #testing }
+PhLOsXMojaveTestImage class >> isClassForLocation: aFileReference [ 
+	^ false
+]
+
 { #category : #'private - accessing' }
 PhLOsXMojaveTestImage >> os [
 	^ TestMacOSXMojavePlatform new


### PR DESCRIPTION
Introduce hooks for custom VM and Image Subclasses, which can specify their own e.g.:
- Executable name
- Default image arguments (GT needs this because the image immediately closes after startup unless `'--no-quit'` is supplied)
- `pharo.version` interpretation

As a working use case example, PharoLauncher-GToolkit allows predownloaded Gtoolkit VMs and images to be used via Launcher. 

## Manage GToolkit images:
1. Download a GToolkit VM/image bundle
1. Put the VM and all libraries into a folder of the form `gt-[version]-architecture` where `version` is the GToolkit *image* version e.g. `gt-0.8.83-x64`. The reason that we use the image version is that the GToolkit team made it clear (Discord -> GT -> General on 8/28/2020) that for the time being, the VM may change with every image version. No assumptions can be made about compatibility other than that.
1. Place the created VM folder in the same folder with the other Launcher VMs
1. Rename the image and changes file to the same base name as their parent folder (e.g. if you downloaded `GlamorousToolkitOSX64-v0.8.83`, then `GlamorousToolkitOSX64-v0.8.83.image`
1.  Create a `pharo.version` file containing `gt-[version]` e.g. `gt-0.8.83` (i.e. the same as the VM minus the architecture)
1. Move the downloaded folder into the folder where your Launcher images are kept
1. Open or refresh Launcher. The image should appear
1. Select the image in Launcher, bring up its context menu, and "Create Template" and go through the dialogs

The template should now be available to create new images.

NB: Didn't add PharoLauncher-GToolkit to the baseline. Should we? There are no dependencies except Launcher, so it can be easily loaded on top of Launcher. Maybe we should at least define the package so that it can be loaded via MetaC API?