### PR TITLE
Fix baseline add gt squeak

### DIFF
--- a/src/BaselineOfPharoLauncher/BaselineOfPharoLauncher.class.st
+++ b/src/BaselineOfPharoLauncher/BaselineOfPharoLauncher.class.st
@@ -46,5 +46,5 @@ BaselineOfPharoLauncher >> baseline: spec [
 			package: #'PharoLauncher-Tests-Functional' with: [
 				spec requires: #(#'PharoLauncher-Core' #'PharoLauncher-Tests-Download'). ].
 		spec 
-			group: 'Default' with: #(#'PharoLauncher-Tests-Core' #'PharoLauncher-Tests-Download' #'PharoLauncher-Core' #'PharoLauncher-Spec2' #'PharoLauncher-Tests-SpecUI' #'PharoLauncher-Tests-Functional'). ].
+			group: 'Default' with: #(#'PharoLauncher-Tests-Core' #'PharoLauncher-Tests-Download' #'PharoLauncher-Core' #'PharoLauncher-Spec2' #'PharoLauncher-Tests-SpecUI' #'PharoLauncher-Tests-Functional' #'PharoLauncher-GToolkit' #'PharoLauncher-Squeak'). ].
 ]

--- a/src/BaselineOfPharoLauncher/BaselineOfPharoLauncher.class.st
+++ b/src/BaselineOfPharoLauncher/BaselineOfPharoLauncher.class.st
@@ -30,6 +30,10 @@ BaselineOfPharoLauncher >> baseline: spec [
 				spec requires: #(#'XMLParser' #'OSSubprocess' #'OSWinSubprocess' #'Ston' #'PharoLauncher-80Compatibility' #'PharoLauncher-Pharo9ToRemove-FileLocator'). ];
 			package: #'PharoLauncher-Spec2' with: [ 
 				spec requires: #(#'PharoLauncher-Core' #Spec2). ];
+			package: #'PharoLauncher-GToolkit' with: [ 
+				spec requires: #(#'PharoLauncher-Core'). ];
+			package: #'PharoLauncher-Squeak' with: [ 
+				spec requires: #(#'PharoLauncher-Core'). ];
 
 			package: #'PharoLauncher-Tests-Core' with: [
 				spec requires: #(#'PharoLauncher-Core' ). ];


### PR DESCRIPTION
### From #502:
Me:
>NB: Didn't add PharoLauncher-GToolkit to the baseline. Should we? There are no dependencies except Launcher, so it can be easily loaded on top of Launcher. Maybe we should at least define the package so that it can be loaded via MetaC API?

@demarey:
>I think we should add the new package to the baseline and maybe in the default loading group. Do you see any reason to not include it?

No reason I can see. Here's the modified baseline...