### PR TITLE
updated Moose sources

### DIFF
--- a/sources.list
+++ b/sources.list
@@ -50,14 +50,19 @@ OrderedCollection [
 			},
 			PhLTemplateSource {
 				#type : #URL,
-				#name : 'Moose Suite 8.0 (development version)',
-				#url : 'https://ci.inria.fr/moose/job/Moose-8/ARCHITECTURE=64,PHARO=80,VERSION=development,VM=vm/lastSuccessfulBuild/artifact/Moose.zip'
-			},
+				#name : 'Moose Suite 9.0 (development) - Pharo 9.0',
+				#url : 'https://github.com/moosetechnology/Moose/releases/download/continuous/Pharo64-9.0-Moose.zip'
+  			},
 			PhLTemplateSource {
 				#type : #URL,
-				#name : 'Moose Suite 7.0 (stable)',
-				#url : 'https://ci.inria.fr/moose/job/moose-7.0-64bit/lastSuccessfulBuild/artifact/moose-7.0-64bit.zip'
-			}
+				#name : 'Moose Suite 9.0 (development) - Pharo 8.0',
+				#url : 'https://github.com/moosetechnology/Moose/releases/download/continuous/Pharo64-8.0-Moose.zip'
+  			},
+			PhLTemplateSource {
+				#type : #URL,
+				#name : 'Moose Suite 8.0 (stable)',
+				#url : 'https://github.com/moosetechnology/Moose/releases/download/v8.0.0/Pharo64-8.0-Moose.zip'
+  			}
 		],
 		#expanded : true
 	},
@@ -97,12 +102,17 @@ OrderedCollection [
 			},
 			PhLTemplateSource {
 				#type : #URL,
-				#name : 'Moose Suite 6.1 (stable)',
+				#name : 'Moose Suite 7.0 (old stable)',
+				#url : 'https://ci.inria.fr/moose/job/moose-7.0-64bit/lastSuccessfulBuild/artifact/moose-7.0-64bit.zip'
+			},
+			PhLTemplateSource {
+				#type : #URL,
+				#name : 'Moose Suite 6.1',
 				#url : 'https://ci.inria.fr/moose/job/moose-6.1/lastSuccessfulBuild/artifact/moose-6.1.zip'
 			},
 			PhLTemplateSource {
 				#type : #URL,
-				#name : 'Moose Suite 6.0 (old stable)',
+				#name : 'Moose Suite 6.0',
 				#url : 'https://ci.inria.fr/moose/job/moose-6.0/lastSuccessfulBuild/artifact/moose-6.0.zip'
 			},
 			PhLTemplateSource {


### PR DESCRIPTION
- Moved Moose 7 to deprecated distributions
- Moose 8 is now the stable version and sources are now on github
- Moose 9 is development version. Sources are from github.