### PR TITLE
Fixed uninitialized accessor of Pharo launch configuration

### DIFF
--- a/src/PharoLauncher-Core/PhLLaunchConfiguration.class.st
+++ b/src/PharoLauncher-Core/PhLLaunchConfiguration.class.st
@@ -198,9 +198,7 @@ PhLLaunchConfiguration >> vmArguments: aCollection [
 { #category : #accessing }
 PhLLaunchConfiguration >> workingDirectory [
 
-	^ self workingDirectory ifNil: [ 
-		  self workingDirectory: image imageFile parent.
-		  self workingDirectory ]
+	^ workingDirectory ifNil: [ image imageFile parent ]
 ]
 
 { #category : #accessing }

--- a/src/PharoLauncher-Core/PhLLaunchConfiguration.class.st
+++ b/src/PharoLauncher-Core/PhLLaunchConfiguration.class.st
@@ -61,7 +61,9 @@ PhLLaunchConfiguration class >> settingsOn: aBuilder [
 
 { #category : #serialization }
 PhLLaunchConfiguration class >> stonAllInstVarNames [
-	^ super stonAllInstVarNames reject: [ :varName | varName = #usePharoSettings ]
+
+	^ super stonAllInstVarNames reject: [ :varName | 
+		  #( #usePharoSettings #workingDirectory ) includes: varName ]
 ]
 
 { #category : #'instance creation' }
@@ -126,8 +128,7 @@ PhLLaunchConfiguration >> initializeWithImage: anImage [
 	image := anImage.
 	name := 'new configuration...'.
 	usePharoSettings := true.
-	imageArguments := anImage defaultArguments.
-	workingDirectory := anImage imageFile parent
+	imageArguments := anImage defaultArguments
 ]
 
 { #category : #testing }
@@ -196,7 +197,10 @@ PhLLaunchConfiguration >> vmArguments: aCollection [
 
 { #category : #accessing }
 PhLLaunchConfiguration >> workingDirectory [
-	^ workingDirectory
+
+	^ self workingDirectory ifNil: [ 
+		  self workingDirectory: image imageFile parent.
+		  self workingDirectory ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- fixed not initialized accessor
- removed working directory reference to be serialized to STON
- fixes #559 