### PR TITLE
replaced dummy command for unit test launch command

### DIFF
--- a/src/PharoLauncher-Tests-Commands/PhLTestLaunchConfiguration.class.st
+++ b/src/PharoLauncher-Tests-Commands/PhLTestLaunchConfiguration.class.st
@@ -14,6 +14,6 @@ PhLTestLaunchConfiguration >> launchProcess [
 	"dummy call, only requirement is that the command is available on supported Operating Systems."
 
 	^ PhLProcessWrapper new
-		  command: 'cd';
+		  command: 'echo';
 		  yourself
 ]


### PR DESCRIPTION
replaced dummy command to work with posix_spawnp ffi call
- fixed unit tests using test launch configuration  on  PhLLaunchImageCommandTest