### PR TITLE
Fixed initialization of default notification center - its streams

### DIFF
--- a/src/PharoLauncher-CLI/ClapContext.extension.st
+++ b/src/PharoLauncher-CLI/ClapContext.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #ClapContext }
-
-{ #category : #'*PharoLauncher-CLI' }
-ClapContext >> launcherModel [
-	^ PharoLauncherCLIModel new
-]

--- a/src/PharoLauncher-CLI/PhLCliClapContext.class.st
+++ b/src/PharoLauncher-CLI/PhLCliClapContext.class.st
@@ -11,6 +11,16 @@ Class {
 }
 
 { #category : #initialization }
+PhLCliClapContext >> initialize [
+
+	super initialize.
+
+	"initialize default notification center with proper streams available on context object"
+	PhLNotificationCenter default outStream: self stdout.
+	PhLNotificationCenter default errorStream: self stderr.
+]
+
+{ #category : #initialization }
 PhLCliClapContext >> launcherModel [
 	^ launcherModel ifNil: [ launcherModel := PharoLauncherCLIModel new ]
 ]

--- a/src/PharoLauncher-CLI/PhLNotificationCenter.class.st
+++ b/src/PharoLauncher-CLI/PhLNotificationCenter.class.st
@@ -1,3 +1,6 @@
+"
+This represents singleton object for accessing errorStream, outStream in methods used by CLI, that do not have any reference to streams of CLI command (or CLI context) object.
+"
 Class {
 	#name : #PhLNotificationCenter,
 	#superclass : #Object,


### PR DESCRIPTION
- removed leftover method on clap context that is defined on sub-class
Wrong (missing) intiializaiton of notification center streams caused issue on CI:
```
Updating VM for running sample image.
[31m#nextPutAll: was sent to nil
[0mUndefinedObject(Object)>>doesNotUnderstand: #nextPutAll:
UndefinedObject>>doesNotUnderstand: #nextPutAll:
PharoLauncherCLIConfiguration class>>configFileNotFound:
[ self configFileNotFound: arg1 ] in PharoLauncherCLIConfiguration class>>configurationFromFile:
```
This was caused by a unitialized stream, used in line: `PhLNotificationCenter default errorStream` in method: `PharoLauncherCLIConfiguration class>>configFileNotFound:`
See: https://ci.inria.fr/pharo-ci-jenkins2/job/PharoLauncher-Pipeline/job/feature%252Fcmd-line/19/console