### PR TITLE
Small shell changes from bash linter checks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ function prepare_image() {
 	esac
 	wget --quiet -O - get.pharo.org/$ARCH_PATH$PHARO | bash
 	wget --quiet -O - get.pharo.org/$ARCH_PATH$VM$PHARO | bash
-	echo $PHARO > 'pharo.version'
+	echo "$PHARO" > 'pharo.version'
 
 	./pharo Pharo.image save PharoLauncher --delete-old
 	./pharo PharoLauncher.image --version > version.txt
@@ -92,7 +92,8 @@ function package_mac_version() {
 	fetch_current_mac_vm_to $(pwd)/$OUTPUT_PATH
 	
 	VERSION=$VERSION_NUMBER APP_NAME=PharoLauncher SHOULD_SIGN=false ./mac/build-dmg.sh
-	local generated_dmg=$(echo *.dmg)
+	local generated_dmg
+	generated_dmg=$(echo *.dmg)
 	mv "$generated_dmg" "PharoLauncher-$VERSION_NUMBER.dmg"
 	generated_dmg=$(echo *.dmg)
 	md5 "$generated_dmg" > "$generated_dmg.md5sum"	
@@ -118,7 +119,7 @@ function copy_current_stable_image_to() {
 	local DEST_PATH=${1:-.} # If no argument given, use current working dir
 	local IMAGES_PATH=$DEST_PATH/images
 	mkdir "$IMAGES_PATH"
-	wget --progress=dot:mega -P $IMAGES_PATH https://files.pharo.org/image/stable/stable-64.zip
+	wget --progress=dot:mega -P "$IMAGES_PATH" https://files.pharo.org/image/stable/stable-64.zip
     mv "$IMAGES_PATH/stable-64.zip" "$IMAGES_PATH/pharo-stable.zip"
 }
 
@@ -212,7 +213,7 @@ linux-package)
   package_linux_version
   ;;
 mac-package)
-  package_mac_version $SHOULD_SIGN
+  package_mac_version "$SHOULD_SIGN"
   ;;
 *)
   echo "No valid target specified! Exiting"

--- a/linux/pharo-launcher
+++ b/linux/pharo-launcher
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # path
-DIR=`readlink -f $0` #resolve symlink
-ROOT=`dirname "$DIR"` #obtain dir of the resolved path
+DIR=$(readlink -f "$0") #resolve symlink
+ROOT=$(dirname "$DIR") #obtain dir of the resolved path
 LINUX="$ROOT/pharo-vm"
 RESOURCES="$ROOT/shared"
 ICONS="$ROOT/icons"

--- a/mac/build-dmg.sh
+++ b/mac/build-dmg.sh
@@ -27,8 +27,8 @@ readonly DMG_FINAL="${VOL_NAME/ /_}.dmg"         # final DMG name will be "Super
 readonly STAGING_DIR="./Install"             # we copy all our stuff into this dir
 
 check_background_image_DPI_and_convert_it_if_not_72_by_72() {
-    local _BACKGROUND_IMAGE_DPI_H=`sips -g dpiHeight ${DMG_BACKGROUND_IMG} | grep -Eo '[0-9]+\.[0-9]+'`
-    local _BACKGROUND_IMAGE_DPI_W=`sips -g dpiWidth ${DMG_BACKGROUND_IMG} | grep -Eo '[0-9]+\.[0-9]+'`
+    local _BACKGROUND_IMAGE_DPI_H=$(sips -g dpiHeight ${DMG_BACKGROUND_IMG} | grep -Eo '[0-9]+\.[0-9]+')
+    local _BACKGROUND_IMAGE_DPI_W=$(sips -g dpiWidth ${DMG_BACKGROUND_IMG} | grep -Eo '[0-9]+\.[0-9]+')
 
     if [ $(echo " $_BACKGROUND_IMAGE_DPI_H != 72.0 " | bc) -eq 1 -o $(echo " $_BACKGROUND_IMAGE_DPI_W != 72.0 " | bc) -eq 1 ]; then
        echo "WARNING: The background image's DPI is not 72.  This will result in distorted backgrounds on Mac OS X 10.7+."
@@ -102,7 +102,7 @@ function sign_mac_app() {
   # See https://code-examples.net/en/q/1344e6a
   security set-key-partition-list -S apple-tool:,apple: -s -k ${keychain_password} "${keychain_name}"
   # debug
-  echo ${sign_identity} >> "id.txt"
+  echo "${sign_identity}" >> "id.txt"
   # Invoke codesign
   if [[ -d "${app_dir}/Contents/MacOS/Plugins" ]]; then # Pharo.app does not (yet) have its plugins in Resources dir
     rm -rf "${app_dir}/Contents/MacOS/Plugins/pkgconfig" # Should be fixed in VM build


### PR DESCRIPTION
This PR includes small changes to get familiar with the codebase.

It applied changes from the linter regarding:

- [Double quote to prevent globbing and word splitting](https://www.shellcheck.net/wiki/SC2086).
- [Use $(...) notation instead of legacy backticked `...`](https://www.shellcheck.net/wiki/SC2006)
- [Declare and assign separately to avoid masking return values](https://www.shellcheck.net/wiki/SC2155)

