### PR TITLE
Follow-up on Moose 11 release.

### DIFF
--- a/sources.list
+++ b/sources.list
@@ -35,18 +35,18 @@ OrderedCollection [
 			},
 			PhLTemplateSource {
 				#type : #URL,
-				#name : 'Moose Suite 11 (development)',
-				#url : 'https://github.com/moosetechnology/Moose/releases/download/continuous/Moose11-development-Pharo64-11.zip'
+				#name : 'Moose Suite 12 (development)',
+				#url : 'https://github.com/moosetechnology/Moose/releases/download/continuous/Moose12-development-Pharo64-12.zip'
 				},
 			PhLTemplateSource {
 				#type : #URL,
-				#name : 'Moose Suite 10 (stable)',
-				#url : 'https://github.com/moosetechnology/Moose/releases/download/v10.x.x/Moose10-stable-Pharo64-10.zip'
+				#name : 'Moose Suite 11 (stable)',
+				#url : 'https://github.com/moosetechnology/Moose/releases/download/v11.x.x/Moose11-stable-Pharo64-11.zip'
   			},
 			PhLTemplateSource {
 				#type : #URL,
-				#name : 'Moose Suite 9.0 (old stable)',
-				#url : 'https://github.com/moosetechnology/Moose/releases/download/v9.x.x/Moose9-stable-Pharo64-10.zip'
+				#name : 'Moose Suite 10 (old stable)',
+				#url : 'https://github.com/moosetechnology/Moose/releases/download/v10.x.x/Moose10-stable-Pharo64-10.zip'
   			}
 		],
 		#expanded : true
@@ -127,8 +127,13 @@ OrderedCollection [
 			},
 			PhLTemplateSource {
 				#type : #URL,
-				#name : 'Moose Suite 8.0 (old stable)',
+				#name : 'Moose Suite 8.0',
 				#url : 'https://github.com/moosetechnology/Moose/releases/download/v8.x.x/Moose8-old-stable-Pharo64-8.0.zip'
+  			},
+			PhLTemplateSource {
+				#type : #URL,
+				#name : 'Moose Suite 9.0',
+				#url : 'https://github.com/moosetechnology/Moose/releases/download/v9.x.x/Moose9-stable-Pharo64-10.zip'
   			}
 		]
 	},


### PR DESCRIPTION
Moose 12 is now the dev version.
Moose 11 is the stable version.
Moose 10 is the old stable.
Moose 9 is now deprecated.