### PR TITLE
Add ‘fileService’ for PharoLauncherApplication allowing ‘.image’ files to be opened through PhLLaunchImageFromDiskCommand

### DIFF
--- a/src/PharoLauncher-Spec2/PharoLauncherApplication.class.st
+++ b/src/PharoLauncher-Spec2/PharoLauncherApplication.class.st
@@ -57,6 +57,17 @@ PharoLauncherApplication class >> defaultInitializationScriptLocation [
 	^ FileLocator launcherUserFilesLocation / 'scripts' 
 ]
 
+{ #category : #'file service' }
+PharoLauncherApplication class >> fileReaderServicesForFile: fullName suffix: suffix [
+
+	<fileService>
+
+	^ suffix = 'image'
+		ifTrue: [
+			{ SimpleServiceEntry provider: self label: 'Launch image' selector: #launchImage: } ]
+		ifFalse: [ #() ]
+]
+
 { #category : #settings }
 PharoLauncherApplication class >> hardResetPersistanceState [
 	^false
@@ -114,6 +125,13 @@ PharoLauncherApplication class >> initializationScriptsLocation: aFileUrl [
 { #category : #testing }
 PharoLauncherApplication class >> isDeployed [
 	^ IsDeployed ifNil: [ IsDeployed := false ]
+]
+
+{ #category : #'file service' }
+PharoLauncherApplication class >> launchImage: fullName [
+
+	(PhLLaunchImageFromDiskCommand forContext: self default mainPresenter)
+		launchImage: (PhLImage location: fullName asFileReference)
 ]
 
 { #category : #'world menu' }


### PR DESCRIPTION
This pull request adds a ‘fileService’ for PharoLauncherApplication allowing ‘.image’ files to be opened through PhLLaunchImageFromDiskCommand. Currently, when an ‘.image’ file is dropped onto Pharo Launcher, an inspector is opened on the FileReference. With the addition of this pull request, the image is launched instead as if the file was selected when using the ‘From disk’ toolbar button.