### PR TITLE
Use `st` instead of `eval` to launch init scripts

### DIFF
--- a/src/PharoLauncher-Core/PhLLaunchImageProcessConfigurator.class.st
+++ b/src/PharoLauncher-Core/PhLLaunchImageProcessConfigurator.class.st
@@ -29,7 +29,7 @@ PhLLaunchImageProcessConfigurator >> configurePotentialInitializationScript [
 	launchConfiguration image initializationScript 
 		ifNotNil: [ :script | 
 						process 
-							addArgument: 'eval';
+							addArgument: 'st';
 							addArgument: script fullName surroundedByDoubleQuotes ].
 ]
 


### PR DESCRIPTION
The PharoLauncher uses the `eval` command line handler to launch init scripts.  This only works up to Pharo 13.  Using the `st` command line handler works for Pharo 14, 13 and older versions