### PR TITLE
Keep original directory structure when unzipping

### DIFF
--- a/src/PharoLauncher-Core/PhLAbstractTemplate.class.st
+++ b/src/PharoLauncher-Core/PhLAbstractTemplate.class.st
@@ -92,7 +92,10 @@ PhLAbstractTemplate >> relocateImageFilesFrom: aDirectory to: targetDirectory [
 		
 	self renameFilesIfNeeded: imageFile to: targetDirectory basename.
 	targetDirectory ensureCreateDirectory.
-	imageFile parent allFiles 
+	
+	"Copy the children directly, moving directories as they are.
+	Thus, keeping the original zip directory structure"
+	imageFile parent children
 		do: [ :each | each moveTo: targetDirectory ]
 ]
 


### PR DESCRIPTION
When unzipping, do not flatten the directory structure, but just move the directories as they are.
This is a nice feature to share resources with the images.

It would be nice if this goes in a patch release soon, for @lucretiomsp

I implemented this and tested on top of  [3.4.3](https://github.com/pharo-project/pharo-launcher/releases/tag/3.4.3)
But I don't know if dev is the right branch for a patch.